### PR TITLE
Game State - simplified solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,4 +159,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/main.py
+++ b/main.py
@@ -67,7 +67,6 @@ class Game():
                                 self.quit()                  
 
                 case "playing":
-                    self.level.update(dt)   
                     if keys[pygame.K_ESCAPE]:
                         if self.playing_gamestate == "unpaused": self.playing_gamestate = "paused"
                         else: self.playing_gamestate = "unpaused"

--- a/main.py
+++ b/main.py
@@ -32,14 +32,14 @@ class Game():
         # assets
         self.tmx_maps = tmx_importer('data/maps')
         self.level_frames = {
-            'animations': support.animation_importer('images', 'animations'),
-            'soil': support.import_folder_dict('images/soil'),
-            'soil water': support.import_folder_dict('images/soil water'),
-            'tomato': support.import_folder('images/plants/tomato'),
-            'corn': support.import_folder('images/plants/corn'),
-            'rain drops': support.import_folder('images/rain/drops'),
-            'rain floor': support.import_folder('images/rain/floor'),
-            'objects': support.import_folder_dict('images/objects')
+            'animations': animation_importer('images', 'animations'),
+            'soil': import_folder_dict('images/soil'),
+            'soil water': import_folder_dict('images/soil water'),
+            'tomato': import_folder('images/plants/tomato'),
+            'corn': import_folder('images/plants/corn'),
+            'rain drops': import_folder('images/rain/drops'),
+            'rain floor': import_folder('images/rain/floor'),
+            'objects': import_folder_dict('images/objects')
         }
         self.overlay_frames = import_folder_dict('images/overlay')
         self.character_frames = character_importer('images/characters')

--- a/main.py
+++ b/main.py
@@ -2,29 +2,33 @@ from src.settings import *
 from src.support import *
 from src.level import Level
 from src.main_menu import MainMenuInternal
+from src.pause_menu import PauseMenu
+from src.settings_menu import SettingsMenu
 
 
-class Game:
-    def __init__(self, mm):
-        self.settings_menu = False
-        self.character_frames: dict[str, AniFrames] | None = None
-        self.level_frames: dict | None = None
-        self.tmx_maps: MapDict | None = None
-        self.overlay_frames: dict[str, pygame.Surface] | None = None
-        self.font: pygame.font.Font | None = None
-        self.sounds: SoundDict | None = None
-        self.main_menu = mm
-        pygame.init()
+
+class Game():
+    def __init__(self):
+        # pygame
         self.screen = pygame.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT))
+        pygame.init()
         pygame.display.set_caption('PyDew')
-        self.clock = pygame.time.Clock()
-        self.running = True
-        self.load_assets()
-        self.running = True
-        self.level = Level(self.tmx_maps, self.character_frames, self.level_frames, self.overlay_frames, self.font,
-                           self.sounds)
 
-    def load_assets(self):
+        # variables 
+        self.gamestate = "main menu"
+        self.playing_gamestate = "unpaused"
+        self.font = import_font(30, 'font/LycheeSoda.ttf')
+        self.clock = pygame.time.Clock()
+        self.sounds = sound_importer('audio', default_volume=0.25)
+        
+
+        self.main_menu = MainMenuInternal(self.font, self.sounds["music"])
+        self.pause_menu = PauseMenu(self.font)
+        self.settings_menu = SettingsMenu(self.font, self.sounds["music"])
+        self.background = pygame.transform.scale(pygame.image.load("images/menu_background/bg.png"), (SCREEN_WIDTH, SCREEN_HEIGHT))
+        self.running = True
+
+        # assets
         self.tmx_maps = tmx_importer('data/maps')
         self.level_frames = {
             'animations': animation_importer('images', 'animations'),
@@ -38,89 +42,87 @@ class Game:
         }
         self.overlay_frames = import_folder_dict('images/overlay')
         self.character_frames = character_importer('images/characters')
-
-        # sounds
-        self.sounds = sound_importer('audio', default_volume=0.25)
-
-        self.font = import_font(30, 'font/LycheeSoda.ttf')
+        
+        self.level = Level(self.tmx_maps, self.character_frames, self.level_frames, self.overlay_frames, self.font, self.sounds)
 
     def run(self):
         while self.running:
             dt = self.clock.tick() / 1000
-            for event in pygame.event.get():
-                if event.type == pygame.QUIT:
-                    pygame.quit()
-                    sys.exit()
             keys = pygame.key.get_just_pressed()
-            self.screen.fill('gray')
-            self.level.update(dt)
-            if self.level.entities["Player"].paused:
-                pause_menu = self.level.entities["Player"].PauseMenu
-                self.settings_menu = False
-                if pause_menu.pressed_play:
-                    self.level.entities["Player"].paused = not self.level.entities["Player"].paused
-                    pause_menu.pressed_play = False
-                elif pause_menu.pressed_quit:
-                    pause_menu.pressed_quit = False
-                    self.running = False
-                    self.main_menu.menu = True
-                    self.level.entities["Player"].paused = False
-                    self.main_menu.run()
-                elif pause_menu.pressed_settings:
-                    self.settings_menu = self.level.entities["Player"].SettingsMenu
-                if self.settings_menu and self.settings_menu.go_back:
-                    self.settings_menu.go_back = False
-                    self.settings_menu = False
-                    pause_menu.pressed_settings = False
-                if self.settings_menu == False:
-                    pause_menu.update()
-                if self.settings_menu:
-                    self.settings_menu.update()
-            if self.settings_menu:
-                if keys[pygame.K_ESCAPE]:
-                    self.settings_menu = False
-                    pause_menu.pressed_settings = False
 
-            pygame.display.update()
-
-
-class MainMenu:
-    def __init__(self):
-        self.menu = True
-        self.screen = pygame.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT))
-        pygame.init()
-        self.font = import_font(30, 'font/LycheeSoda.ttf')
-        pygame.display.set_caption('PyDew')
-        self.clock = pygame.time.Clock()
-        self.sounds = sound_importer('audio', default_volume=0.25)
-        self.main_menu = MainMenuInternal(self.font, self.sounds["music"])
-        self.background = pygame.image.load("images/menu_background/bg.png")
-        self.background = pygame.transform.scale(self.background, (SCREEN_WIDTH, SCREEN_HEIGHT))
-        self.game = Game(self)
-
-    def run(self):
-        while self.menu:
-            dt = self.clock.tick() / 1000
             for event in pygame.event.get():
-                if event.type == pygame.QUIT:
-                    pygame.quit()
-                    sys.exit()
-            if self.main_menu.pressed_play:
-                self.sounds["music"].stop()
-                self.main_menu.pressed_play = False
-                self.game.running = True
-                self.game.run()
-                self.menu = False
-            elif self.main_menu.pressed_quit:
-                self.main_menu.pressed_quit = False
-                self.menu = False
-                pygame.quit()
-                sys.exit()
-            self.screen.blit(self.background, (0, 0))
-            self.main_menu.update()
+                if event.type == pygame.QUIT:     
+                    self.quit()
+
+            # UPDATE -----------------------------------
+            match self.gamestate:
+                case "main menu":
+                        match self.main_menu.input(keys):
+                            case "Play":
+                                self.gamestate = "playing"
+                                self.level.entities["Player"].paused = False
+                                self.playing_gamestate = "unpaused"
+                            case "Quit":
+                                self.quit()                  
+
+                case "playing":
+                    self.level.update(dt)   
+                    if keys[pygame.K_ESCAPE]:
+                        if self.playing_gamestate == "unpaused": self.playing_gamestate = "paused"
+                        else: self.playing_gamestate = "unpaused"
+                        
+
+                    match self.playing_gamestate:
+                        case "unpaused":
+                            self.level.entities["Player"].paused = False
+
+                        case "paused":
+                            self.level.entities["Player"].paused = True
+                            match self.pause_menu.input(keys):
+                                case "resume":
+                                    self.level.entities["Player"].paused = False
+                                    self.playing_gamestate = "unpaused"
+                                case "options":
+                                    self.playing_gamestate = "options"
+                                case "main menu":
+                                    self.gamestate = "main menu"
+                                    self.playing_gamestate = "unpaused"
+
+                        case "options":
+                            self.level.entities["Player"].paused = True
+                            match self.settings_menu.input(keys):
+                                case "back":
+                                    self.playing_gamestate = "paused"
+                                
+
+
+            # DRAW ------------------------------------
+            self.screen.fill('gray')
+
+            match self.gamestate:
+                case "main menu":
+                    self.screen.blit(self.background, (0, 0))
+                    self.main_menu.draw()
+
+                case "playing":
+                    self.level.draw(dt)
+
+                    match self.playing_gamestate:
+                        case "unpaused":
+                            pass
+                        case "paused":
+                            self.pause_menu.draw()
+                        case "options":
+                            self.settings_menu.draw()
+            
+
             pygame.display.update()
+
+    def quit(self):
+        pygame.quit()
+        sys.exit()
 
 
 if __name__ == '__main__':
-    game = MainMenu()
+    game = Game()
     game.run()

--- a/main.py
+++ b/main.py
@@ -1,16 +1,19 @@
 from src.settings import *
 from src.support import *
 from src.level import Level
-from src.main_menu import main_menu
+from src.main_menu import MainMenuInternal
+
 
 class Game:
-    def __init__(self):
+    def __init__(self, mm):
+        self.settings_menu = False
         self.character_frames: dict[str, AniFrames] | None = None
         self.level_frames: dict | None = None
         self.tmx_maps: MapDict | None = None
         self.overlay_frames: dict[str, pygame.Surface] | None = None
         self.font: pygame.font.Font | None = None
         self.sounds: SoundDict | None = None
+        self.main_menu = mm
         pygame.init()
         self.screen = pygame.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT))
         pygame.display.set_caption('PyDew')
@@ -18,7 +21,8 @@ class Game:
         self.running = True
         self.load_assets()
         self.running = True
-        self.level = Level(self.tmx_maps, self.character_frames, self.level_frames, self.overlay_frames, self.font, self.sounds)
+        self.level = Level(self.tmx_maps, self.character_frames, self.level_frames, self.overlay_frames, self.font,
+                           self.sounds)
 
     def load_assets(self):
         self.tmx_maps = tmx_importer('data/maps')
@@ -51,7 +55,7 @@ class Game:
             self.screen.fill('gray')
             self.level.update(dt)
             if self.level.entities["Player"].paused:
-                pause_menu = self.level.entities["Player"].pause_menu
+                pause_menu = self.level.entities["Player"].PauseMenu
                 self.settings_menu = False
                 if pause_menu.pressed_play:
                     self.level.entities["Player"].paused = not self.level.entities["Player"].paused
@@ -63,7 +67,7 @@ class Game:
                     self.level.entities["Player"].paused = False
                     self.main_menu.run()
                 elif pause_menu.pressed_settings:
-                    self.settings_menu = self.level.entities["Player"].settings_menu
+                    self.settings_menu = self.level.entities["Player"].SettingsMenu
                 if self.settings_menu and self.settings_menu.go_back:
                     self.settings_menu.go_back = False
                     self.settings_menu = False
@@ -72,12 +76,13 @@ class Game:
                     pause_menu.update()
                 if self.settings_menu:
                     self.settings_menu.update()
-            if self.settings_menu != False:
+            if self.settings_menu:
                 if keys[pygame.K_ESCAPE]:
                     self.settings_menu = False
                     pause_menu.pressed_settings = False
 
             pygame.display.update()
+
 
 class MainMenu:
     def __init__(self):
@@ -88,10 +93,11 @@ class MainMenu:
         pygame.display.set_caption('PyDew')
         self.clock = pygame.time.Clock()
         self.sounds = sound_importer('audio', default_volume=0.25)
-        self.main_menu = main_menu(self.font, self.sounds["music"])
+        self.main_menu = MainMenuInternal(self.font, self.sounds["music"])
         self.background = pygame.image.load("images/menu_background/bg.png")
         self.background = pygame.transform.scale(self.background, (SCREEN_WIDTH, SCREEN_HEIGHT))
         self.game = Game(self)
+
     def run(self):
         while self.menu:
             dt = self.clock.tick() / 1000
@@ -113,6 +119,7 @@ class MainMenu:
             self.screen.blit(self.background, (0, 0))
             self.main_menu.update()
             pygame.display.update()
+
 
 if __name__ == '__main__':
     game = MainMenu()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pygame-ce>=2.5.0
+jsmin>=3.0.1

--- a/src/groups.py
+++ b/src/groups.py
@@ -1,11 +1,5 @@
 import pygame
-from src.settings import (
-    LAYERS,
-    SCREEN_HEIGHT,
-    SCREEN_WIDTH,
-    Coordinate,
-)
-
+from src.settings import *
 
 # TODO : we could replace this with pygame.sprite.LayeredUpdates, as that
 # is a subclass of pygame.sprite.Group that natively supports layers

--- a/src/level.py
+++ b/src/level.py
@@ -43,9 +43,9 @@ class Level:
         self.menu = Menu(self.entities['Player'], self.toggle_shop, font)
         self.shop_active = False
 
+
     def setup(self, tmx_maps: MapDict, character_frames, level_frames):
-        self.sounds["music"].set_volume(0.1)
-        self.sounds["music"].play(-1)
+
         # environment
         for layer in ['Lower ground', 'Upper ground']:
             for x, y, surf in tmx_maps['main'].get_layer_by_name(layer).tiles():
@@ -141,7 +141,7 @@ class Level:
         # plants
         self.soil_layer.update_plants()
 
-        self.sky.set_time(6, 0)  # set to 0600 hours upon sleeping
+        self.sky.set_time(0, 0)  # set to 0600 hours upon sleeping
 
         # soil
         self.soil_layer.remove_water()
@@ -183,10 +183,12 @@ class Level:
     def toggle_shop(self):
         self.shop_active = not self.shop_active
 
-    def update(self, dt):
+    def draw(self, dt):
+        self.all_sprites.draw(self.entities['Player'].rect.center)
+
         if not self.shop_active:
             self.all_sprites.update(dt)
-        self.all_sprites.draw(self.entities['Player'].rect.center)
+        
         self.plant_collision()
         self.overlay.display(self.sky.get_time())
         self.sky.display(dt)

--- a/src/level.py
+++ b/src/level.py
@@ -7,19 +7,8 @@ from src.transition import Transition
 from src.sky import Sky, Rain
 from src.overlay import Overlay
 from src.menu import Menu
-from src.sprites import (
-    AnimatedSprite,
-    ParticleSprite,
-    Tree,
-    Sprite,
-    Player,
-)
-from src.settings import (
-    TILE_SIZE,
-    SCALE_FACTOR,
-    LAYERS,
-    MapDict,
-)
+from src.sprites import *
+from src.settings import *
 
 
 class Level:

--- a/src/level.py
+++ b/src/level.py
@@ -87,27 +87,41 @@ class Level:
                                              collision_sprites=self.collision_sprites,
                                              apply_tool=self.apply_tool,
                                              interact=self.interact,
-                                             sounds=self.sounds, 
+                                             sounds=self.sounds,
                                              font=self.font)
 
-    def apply_tool(self, tool, pos, entity):
-        if tool == 'axe':
-            for tree in self.tree_sprites:
-                if tree.rect.collidepoint(pos):
-                    tree.hit(entity)
-                    # self.create_particle(tree)
-                    self.sounds['axe'].play()
+    def apply_tool(self, tool: FarmingTool, pos, entity):
+        match tool:
+            case FarmingTool.AXE:
+                for tree in self.tree_sprites:
+                    if tree.rect.collidepoint(pos):
+                        tree.hit(entity)
+                        self.sounds['axe'].play()
+            case FarmingTool.HOE:
+                self.soil_layer.hoe(pos, hoe_sound=self.sounds['hoe'])
+            case FarmingTool.WATERING_CAN:
+                self.soil_layer.water(pos)
+                self.sounds['water'].play()
+            case _:  # All seeds
+                self.soil_layer.plant_seed(pos, entity.available_seeds[tool - FarmingTool.get_first_seed_id()],
+                                           entity.inventory, plant_sounds=[self.sounds['plant'], self.sounds['cant_plant']])
 
-        if tool == 'hoe':
-            self.soil_layer.hoe(pos, hoe_sound=self.sounds['hoe'])
+        # if tool == 'axe':
+        #     for tree in self.tree_sprites:
+        #         if tree.rect.collidepoint(pos):
+        #             tree.hit(entity)
+        #             self.sounds['axe'].play()
 
-        if tool == 'water':
-            self.soil_layer.water(pos)
-            self.sounds['water'].play()
+        # if tool == 'hoe':
+        #     self.soil_layer.hoe(pos, hoe_sound=self.sounds['hoe'])
 
-        if tool in ('corn', 'tomato'):
-            self.soil_layer.plant_seed(pos, tool, entity.inventory,
-                                       plant_sounds=[self.sounds['plant'], self.sounds['cant_plant']])
+        # if tool == 'water':
+        #     self.soil_layer.water(pos)
+        #     self.sounds['water'].play()
+        #
+        # if tool in ('corn', 'tomato'):
+        #     self.soil_layer.plant_seed(pos, tool, entity.inventory,
+        #                                plant_sounds=[self.sounds['plant'], self.sounds['cant_plant']])
 
     def create_particle(self, sprite):
         ParticleSprite(sprite.rect.topleft, sprite.image, self.all_sprites)
@@ -137,7 +151,7 @@ class Level:
             self.soil_layer.water_all()
 
         # apples on the trees
-        for tree in self.tree_sprites: # No need to iterate using explicit sprites() call. Iterating over a sprite group normally will do the same thing
+        for tree in self.tree_sprites:  # No need to iterate using explicit sprites() call. Iterating over a sprite group normally will do the same thing
             for apple in tree.apple_sprites:
                 apple.kill()
             tree.create_fruit()

--- a/src/main_menu.py
+++ b/src/main_menu.py
@@ -4,12 +4,12 @@ from .settings import *
 
 class MainMenuInternal:
     def __init__(self, font, music):
-
         # general setup
         self.display_surface = pygame.display.get_surface()
         self.font = font
         self.index = 0
         self.music = music
+
         # options
         self.width = 400
         self.space = 10
@@ -18,10 +18,8 @@ class MainMenuInternal:
         self.pressed_quit = False
         # entries
         self.options = ("Play", "Quit")
-        self.setup()
-
-    def setup(self):
-        self.music.play()
+        
+        self.music.play() 
         # create the text surfaces
         self.text_surfs = []
         self.total_height = 0
@@ -36,22 +34,15 @@ class MainMenuInternal:
         self.main_rect = pygame.Rect(SCREEN_WIDTH / 2 - self.width / 2, self.menu_top, self.width, self.total_height)
 
         # buy / sell text surface
-    def input(self):
-        keys = pygame.key.get_just_pressed()
 
+    def input(self, keys):
         self.index = (self.index + int(keys[pygame.K_DOWN]) - int(keys[pygame.K_UP])) % len(self.options)
 
         if keys[pygame.K_SPACE]:
             current_item = self.options[self.index]
-            if 'Play' in current_item:
-                if not self.pressed_quit:
-                    self.pressed_play = True
-            elif 'Quit' in current_item:
-                if not self.pressed_play:
-                    self.pressed_quit = True
-
+            return current_item
+        
     def show_entry(self, text_surf, top, index, text_index):
-
         # background
         bg_rect = pygame.Rect(self.main_rect.left, top, self.width, text_surf.get_height() + (self.padding * 2))
         pygame.draw.rect(self.display_surface, 'White', bg_rect, 0, 4)
@@ -64,16 +55,13 @@ class MainMenuInternal:
         if index == text_index:
             pygame.draw.rect(self.display_surface, 'black', bg_rect, 4, 4)
 
-    def main_menu_title(self):
+    def draw(self):
         text_surf = self.font.render('Main Menu', False, 'Black')
         text_rect = text_surf.get_frect(midtop=(SCREEN_WIDTH / 2, SCREEN_HEIGHT / 20))
 
         pygame.draw.rect(self.display_surface, 'White', text_rect.inflate(10, 10), 0, 4)
         self.display_surface.blit(text_surf, text_rect)
-    def update(self):
-        self.input()
-        self.main_menu_title()
-        
+
         for text_index, text_surf in enumerate(self.text_surfs):
             top = self.main_rect.top + text_index * (text_surf.get_height() + (self.padding * 2) + self.space)
             self.show_entry(text_surf, top, self.index, text_index)

--- a/src/main_menu.py
+++ b/src/main_menu.py
@@ -1,8 +1,5 @@
 import pygame
-from src.settings import (
-    SCREEN_HEIGHT,
-    SCREEN_WIDTH,
-)
+from src.settings import *
 
 
 class MainMenuInternal:

--- a/src/main_menu.py
+++ b/src/main_menu.py
@@ -2,7 +2,7 @@ import pygame
 from .settings import *
 
 
-class main_menu:
+class MainMenuInternal:
     def __init__(self, font, music):
 
         # general setup

--- a/src/menu.py
+++ b/src/menu.py
@@ -54,6 +54,7 @@ class Menu:
 
         if keys[pygame.K_ESCAPE]:
             self.toggle_menu()
+            
 
         if keys[pygame.K_SPACE]:
             current_item = self.options[self.index]
@@ -91,7 +92,6 @@ class Menu:
             self.display_surface.blit(surf, pos_rect)
 
     def update(self):
-        self.input()
         self.display_money()
 
         for text_index, text_surf in enumerate(self.text_surfs):

--- a/src/menu.py
+++ b/src/menu.py
@@ -1,10 +1,5 @@
 import pygame
-from src.settings import (
-    SCREEN_HEIGHT,
-    SCREEN_WIDTH,
-    PURCHASE_PRICES,
-    SALE_PRICES,
-)
+from src.settings import *
 
 
 class Menu:

--- a/src/overlay.py
+++ b/src/overlay.py
@@ -1,7 +1,5 @@
 import pygame
-from src.settings import (
-    OVERLAY_POSITIONS,
-)
+from src.settings import *
 
 
 

--- a/src/overlay.py
+++ b/src/overlay.py
@@ -1,35 +1,42 @@
 from .settings import *
 
+
 class Overlay:
-	def __init__(self,entity, overlay_frames):
+    def __init__(self, entity, overlay_frames):
 
-		# general setup
-		self.display_surface = pygame.display.get_surface()
-		self.player = entity
+        # general setup
+        self.display_surface = pygame.display.get_surface()
+        self.player = entity
 
-		# imports 
-		self.overlay_frames = overlay_frames
+        # imports
+        self.overlay_frames = overlay_frames
 
-	def display(self, time):
+    def display(self, time):
 
-		# tool
-		tool_surf = self.overlay_frames[self.player.current_tool]
-		tool_rect = tool_surf.get_frect(midbottom = OVERLAY_POSITIONS['tool'])
-		self.display_surface.blit(tool_surf,tool_rect)
+        # tool
+        tool_surf = self.overlay_frames[self.player.get_current_tool_string()]
+        tool_rect = tool_surf.get_frect(midbottom=OVERLAY_POSITIONS['tool'])
+        self.display_surface.blit(tool_surf, tool_rect)
 
-		# seeds
-		seed_surf = self.overlay_frames[self.player.current_seed]
-		seed_rect = seed_surf.get_frect(midbottom = OVERLAY_POSITIONS['seed'])
-		self.display_surface.blit(seed_surf,seed_rect)
+        # seeds
+        seed_surf = self.overlay_frames[self.player.get_current_seed_string()]
+        seed_rect = seed_surf.get_frect(midbottom=OVERLAY_POSITIONS['seed'])
+        self.display_surface.blit(seed_surf, seed_rect)
 
-		# clock
-		font = pygame.font.SysFont('Arial', 30)	# font/size is temporary
-		
-		if(time[0] < 10): hours = f"0{time[0]}"			# if hours are less than 10, add a 0 to stay in the hh:mm format
-		else: hours = f"{time[0]}"
-		
-		if(time[1] < 10): minutes = f"0{time[1]}"		# if minutes are less than 10, add a 0 to stay in the hh:mm format
-		else: minutes = f"{time[1]}"
-		
-		text_surface = font.render(f"{hours}:{minutes}", False, (255,255,255))
-		self.display_surface.blit(text_surface, (10,10))
+        # clock
+        font = pygame.font.SysFont('Arial', 30)  # font/size is temporary
+
+        hours = str(time[0]).rjust(2, "0")  # if hours are less than 10, add a 0 to stay in the hh:mm format
+        minutes = str(time[1]).rjust(2, "0")  # if minutes are less than 10, add a 0 to stay in the hh:mm format
+        # if time[0] < 10:
+        #     hours = f"0{time[0]}"
+        # else:
+        #     hours = f"{time[0]}"
+
+        # if (time[1] < 10):
+        #     minutes = f"0{time[1]}"  # if minutes are less than 10, add a 0 to stay in the hh:mm format
+        # else:
+        #     minutes = f"{time[1]}"
+
+        text_surface = font.render(f"{hours}:{minutes}", False, (255, 255, 255))
+        self.display_surface.blit(text_surface, (10, 10))

--- a/src/pause_menu.py
+++ b/src/pause_menu.py
@@ -1,8 +1,5 @@
 import pygame
-from src.settings import (
-    SCREEN_HEIGHT,
-    SCREEN_WIDTH,
-)
+from src.settings import *
 
 
 class PauseMenu:

--- a/src/pause_menu.py
+++ b/src/pause_menu.py
@@ -4,7 +4,6 @@ from .settings import *
 
 class PauseMenu:
     def __init__(self, font):
-
         # general setup
         self.display_surface = pygame.display.get_surface()
         self.font = font
@@ -17,10 +16,8 @@ class PauseMenu:
         self.pressed_play = False
         self.pressed_quit = False
         # entries
-        self.options = ("Resume", "Options", "Main Menu")
-        self.setup()
-
-    def setup(self):
+        self.options = ("resume", "options", "main menu")
+    
         # create the text surfaces
         self.text_surfs = []
         self.total_height = 0
@@ -35,28 +32,15 @@ class PauseMenu:
         self.main_rect = pygame.Rect(SCREEN_WIDTH / 2 - self.width / 2, self.menu_top, self.width, self.total_height)
 
         # buy / sell text surface
-    def input(self):
-        keys = pygame.key.get_just_pressed()
-
+        
+    def input(self, keys):
         self.index = (self.index + int(keys[pygame.K_DOWN]) - int(keys[pygame.K_UP])) % len(self.options)
 
         if keys[pygame.K_SPACE]:
             current_item = self.options[self.index]
-            if 'Resume' in current_item:
-                if not self.pressed_quit:
-                    self.pressed_play = True
-                    self.index = 0
-            if 'Options' in current_item:
-                if not self.pressed_quit and not self.pressed_play:
-                    self.pressed_settings = True
-                    self.index = 0
-            elif 'Main Menu' in current_item:
-                if not self.pressed_play:
-                    self.pressed_quit = True
-                    self.index = 0
+            return current_item
 
     def show_entry(self, text_surf, top, index, text_index):
-
         # background
         bg_rect = pygame.Rect(self.main_rect.left, top, self.width, text_surf.get_height() + (self.padding * 2))
         pygame.draw.rect(self.display_surface, 'White', bg_rect, 0, 4)
@@ -69,16 +53,15 @@ class PauseMenu:
         if index == text_index:
             pygame.draw.rect(self.display_surface, 'black', bg_rect, 4, 4)
 
-    def main_menu_title(self):
+    def draw(self):
+        for text_index, text_surf in enumerate(self.text_surfs):
+            top = self.main_rect.top + text_index * (text_surf.get_height() + (self.padding * 2) + self.space)
+            self.show_entry(text_surf, top, self.index, text_index)
+
         text_surf = self.font.render('Pause Menu', False, 'Black')
         text_rect = text_surf.get_frect(midtop=(SCREEN_WIDTH / 2, SCREEN_HEIGHT / 20))
 
         pygame.draw.rect(self.display_surface, 'White', text_rect.inflate(10, 10), 0, 4)
         self.display_surface.blit(text_surf, text_rect)
-    def update(self):
-        self.input()
-        self.main_menu_title()
+
         
-        for text_index, text_surf in enumerate(self.text_surfs):
-            top = self.main_rect.top + text_index * (text_surf.get_height() + (self.padding * 2) + self.space)
-            self.show_entry(text_surf, top, self.index, text_index)

--- a/src/pause_menu.py
+++ b/src/pause_menu.py
@@ -2,7 +2,7 @@ import pygame
 from .settings import *
 
 
-class pause_menu:
+class PauseMenu:
     def __init__(self, font):
 
         # general setup

--- a/src/settings.py
+++ b/src/settings.py
@@ -18,7 +18,7 @@ if sys.version_info < (3, 12):
         DeprecationWarning,
     )
 import pytmx
-
+from pytmx.util_pygame import load_pygame
 from enum import IntEnum, StrEnum
 from types import FunctionType as Function
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -9,6 +9,7 @@ from os.path import join
 from os import walk, path, sep, listdir
 from pytmx.util_pygame import load_pygame
 import pytmx
+from enum import IntEnum, StrEnum
 from types import FunctionType as Function
 
 type Coordinate = tuple[int | float, int | float]
@@ -56,3 +57,49 @@ APPLE_POS = {
     'small': [(18, 17), (30, 37), (12, 50), (30, 45), (20, 30), (30, 10)],
     'default': [(30, 24), (60, 65), (50, 50), (16, 40), (45, 50), (42, 70)]
 }
+
+
+class ItemToUse(IntEnum):
+    """Both available options for Player.use_tool. If any more have to be added, put them as members of this enum."""
+    REGULAR_TOOL = 0
+    SEED = 1
+
+
+class FarmingTool(IntEnum):
+    """Notably used to distinguish the different farming tools (including seeds) in-code."""
+    NONE = 0  # Possible placeholder value if needed somewhere
+    AXE = 1
+    HOE = 2
+    WATERING_CAN = 3
+    CORN_SEED = 4
+    TOMATO_SEED = 5
+
+    @property
+    def _swinging_tools(self):
+        return {self.HOE, self.AXE}
+
+    def is_swinging_tool(self):
+        return self in self._swinging_tools
+
+    @classmethod
+    def get_first_tool_id(cls):
+        """Return the first tool ID. This might change in the course of development."""
+        return cls.AXE
+
+    @classmethod
+    def get_tool_count(cls):
+        return cls.get_first_seed_id() - cls.get_first_tool_id()
+
+    @classmethod
+    def get_seed_count(cls):
+        return len(cls) - cls.get_first_seed_id()
+
+    @classmethod
+    def get_first_seed_id(cls):
+        """Same as get_first_tool_id, but for the seeds. Duh."""
+        return cls.CORN_SEED
+
+
+class InventoryResource(IntEnum):
+    """All stored items in the inventory."""
+    pass

--- a/src/settings_menu.py
+++ b/src/settings_menu.py
@@ -1,8 +1,5 @@
 import pygame
-from src.settings import (
-    SCREEN_HEIGHT,
-    SCREEN_WIDTH,
-)
+from src.settings import *
 
 
 class SettingsMenu:

--- a/src/settings_menu.py
+++ b/src/settings_menu.py
@@ -18,7 +18,7 @@ class SettingsMenu:
         self.current_item = 0
         self.slider = None
         # entries
-        self.options = ("Keybinds", "Volume", "Back")
+        self.options = ("keybinds", "volume", "back")
         self.option_data = { 0: {
                 "Up": "UP ARROW",
                 "Down": "DOWN ARROW",
@@ -33,12 +33,10 @@ class SettingsMenu:
              "slider": self.slider,
             },
             2: {
-             "Back": "Press Space to go back to the main menu!"
+             "back": "Press Space to go back to the main menu!"
             },
         }
-        self.setup()
 
-    def setup(self):
         # create the text surfaces
         self.text_surfs = []
         self.total_height = 0
@@ -52,19 +50,18 @@ class SettingsMenu:
         self.main_rect = pygame.Rect(SCREEN_WIDTH / 20 - self.width / 20, self.menu_top, self.width, self.total_height)
 
         # buy / sell text surface
-    def input(self):
-        if self.slider:
-            for event in pygame.event.get():
-                self.slider.handle_event(event)
-        keys = pygame.key.get_just_pressed()
+        
+    def input(self, keys):
+        #  THIS CODE FOR THE SLIDER CAUSES UNEXPECTED LAG WHEN GOING THROUGH THE MENU - CURRENTLY NOT FUNCTIONAL
+        # if self.slider:
+        #     for event in pygame.event.get():
+        #         self.slider.handle_event(event)
 
         self.index = (self.index + int(keys[pygame.K_DOWN]) - int(keys[pygame.K_UP])) % len(self.options)
 
         if keys[pygame.K_SPACE]:
             self.current_item = self.options[self.index]
-            if 'Back' in self.current_item:
-                self.go_back = True
-                self.index = 0
+            return self.current_item
 
     def show_entry(self, text_surf, top, index, text_index):
         # background
@@ -99,16 +96,12 @@ class SettingsMenu:
             pygame.draw.rect(self.display_surface, 'black', bg_rect, 4, 4)
             pygame.draw.rect(self.display_surface, 'white', big_rect, 4, 4)
 
-    def main_menu_title(self):
+    def draw(self):
         text_surf = self.font.render('Settings', False, 'Black')
         text_rect = text_surf.get_frect(midtop=(SCREEN_WIDTH / 2, SCREEN_HEIGHT / 20))
 
         pygame.draw.rect(self.display_surface, 'White', text_rect.inflate(10, 10), 0, 4)
         self.display_surface.blit(text_surf, text_rect)
-
-    def update(self):
-        self.input()
-        self.main_menu_title()
         
         for text_index, text_surf in enumerate(self.text_surfs):
             top = self.main_rect.top + text_index * (text_surf.get_height() + (self.padding * 2) + self.space)

--- a/src/settings_menu.py
+++ b/src/settings_menu.py
@@ -2,7 +2,7 @@ import pygame
 from .settings import *
 
 
-class settings_menu:
+class SettingsMenu:
     def __init__(self, font, sounds):
 
         # general setup

--- a/src/soil.py
+++ b/src/soil.py
@@ -1,14 +1,6 @@
-import pygame
-from src.settings import (
-    TILE_SIZE,
-    SCALE_FACTOR,
-    LAYERS,
-)
-from src.sprites import (
-    Plant,
-    Sprite,
-)
-import random
+from .settings import *
+from .sprites import Sprite, Plant
+from random import *
 
 
 class SoilLayer:

--- a/src/soil.py
+++ b/src/soil.py
@@ -48,7 +48,6 @@ class SoilLayer:
                     surf = choice(list(self.level_frames['soil water'].values()))
                     Sprite((x,y), surf, [self.all_sprites, self.water_sprites], LAYERS['soil water'])
 
-
     def check_watered(self, pos):
         x = int(pos[0] / (TILE_SIZE * SCALE_FACTOR))
         y = int(pos[1] / (TILE_SIZE * SCALE_FACTOR))

--- a/src/sprites.py
+++ b/src/sprites.py
@@ -1,9 +1,10 @@
 from .settings import *
-from .timer import Timer
+from .timer import Timer 
 from .support import generate_particle_surf
 from random import randint, choice
 from .pause_menu import PauseMenu
 from .settings_menu import SettingsMenu
+import random
 
 class Sprite(pygame.sprite.Sprite):
     def __init__(self,
@@ -25,7 +26,7 @@ class ParticleSprite(Sprite):
         white_surf = pygame.mask.from_surface(surf).to_surface()
         white_surf.set_colorkey('black')
         super().__init__(pos, white_surf, groups, LAYERS['particles'])
-        self.timer = timer.Timer(duration, autostart=True, func=self.kill)
+        self.timer = Timer(duration, autostart=True, func=self.kill)
 
     def update(self, dt):
         self.timer.update()
@@ -77,11 +78,11 @@ class Tree(CollideableSprite):
             (30 * SCALE_FACTOR, 20 * SCALE_FACTOR),
         )
         self.name = name
-        self.part_surf = support.generate_particle_surf(self.image)
+        self.part_surf = generate_particle_surf(self.image)
         self.apple_surf = apple_surf
         self.stump_surf = stump_surf
         self.health = 5
-        self.timer = timer.Timer(300, func=self.unhit)
+        self.timer = Timer(300, func=self.unhit)
         self.hitbox = None
         self.was_hit = False
         self.alive = True
@@ -122,7 +123,7 @@ class Tree(CollideableSprite):
             entity.add_resource('apple')
         if self.health < 0 and self.alive:
             entity.add_resource("wood", 5)
-        self.image = support.generate_particle_surf(self.image)
+        self.image = generate_particle_surf(self.image)
         self.timer.activate()
 
 class AnimatedSprite(Sprite):
@@ -140,7 +141,7 @@ class AnimatedSprite(Sprite):
 class WaterDrop(Sprite):
     def __init__(self, pos, surf, groups, moving, z):
         super().__init__(pos, surf, groups, z)
-        self.timer = timer.Timer(
+        self.timer = Timer(
             random.randint(400, 600),
             autostart=True,
             func=self.kill,

--- a/src/sprites.py
+++ b/src/sprites.py
@@ -13,7 +13,6 @@ class Sprite(pygame.sprite.Sprite):
         self.z = z
         self.name = name
 
-
 class ParticleSprite(Sprite):
     def __init__(self, pos, surf, groups, duration=300):
         white_surf = pygame.mask.from_surface(surf).to_surface()
@@ -24,12 +23,10 @@ class ParticleSprite(Sprite):
     def update(self, dt):
         self.timer.update()
 
-
 class CollideableSprite(Sprite):
     def __init__(self, pos, surf, groups, shrink, z=LAYERS['main']):
         super().__init__(pos, surf, groups, z)
         self.hitbox_rect = self.rect.inflate(-shrink[0], -shrink[1])
-
 
 class Plant(CollideableSprite):
     def __init__(self, seed_type, groups, soil_sprite, frames, check_watered):
@@ -60,7 +57,6 @@ class Plant(CollideableSprite):
 
             self.image = self.frames[int(self.age)]
             self.rect = self.image.get_frect(midbottom=self.soil.rect.midbottom + pygame.math.Vector2(0, 2))
-
 
 class Tree(CollideableSprite):
     def __init__(self, pos, surf, groups, name, apple_surf, stump_surf):
@@ -113,7 +109,6 @@ class Tree(CollideableSprite):
         self.image = generate_particle_surf(self.image)
         self.timer.activate()
 
-
 class AnimatedSprite(Sprite):
     def __init__(self, pos, frames, groups, z=LAYERS['main']):
         self.frames, self.frame_index = frames, 0
@@ -125,7 +120,6 @@ class AnimatedSprite(Sprite):
 
     def update(self, dt):
         self.animate(dt)
-
 
 class WaterDrop(Sprite):
     def __init__(self, pos, surf, groups, moving, z):
@@ -143,12 +137,10 @@ class WaterDrop(Sprite):
         if self.moving:
             self.rect.topleft += self.direction * self.speed * dt
 
-
 class Entity(Sprite):
     def __init__(self, pos, frames, groups, z=LAYERS['main']):
         self.frames, self.frame_index, self.state = frames, 0, 'idle'
         super().__init__(pos, frames[self.state][0], groups, z)
-
 
 class Player(CollideableSprite):
     def __init__(self, pos: Coordinate, frames, groups, collision_sprites: pygame.sprite.Group, apply_tool: Function, interact: Function, sounds: SoundDict, font: pygame.Font):
@@ -204,8 +196,8 @@ class Player(CollideableSprite):
         # movement
         if not self.tool_active and not self.blocked:
             recent_keys = pygame.key.get_just_pressed()
-            if recent_keys[pygame.K_ESCAPE]:
-                self.paused = not self.paused
+            
+            if self.paused:
                 self.direction.y = 0
                 self.direction.x = 0
 

--- a/src/support.py
+++ b/src/support.py
@@ -2,6 +2,7 @@ from .settings import *
 from os import *
 
 
+
 def resource_path(relative_path: str):
     """Get absolute path to resource, works for dev and for PyInstaller"""
     relative_path = relative_path.replace("/", sep)
@@ -46,7 +47,7 @@ def tmx_importer(tmx_path: str) -> MapDict:
     for folder_path, _, file_names in walk(resource_path(tmx_path)):
         for file_name in file_names:
             full_path = path.join(folder_path, file_name)
-            files[file_name.split('.')[0]] = pygame.load_pygame(full_path)
+            files[file_name.split('.')[0]] = load_pygame(full_path)
     return files
 
 

--- a/src/support.py
+++ b/src/support.py
@@ -10,16 +10,13 @@ def resource_path(relative_path: str):
         base_path = path.dirname(path.abspath(sys.argv[0]))
     return path.join(base_path, relative_path)
 
-
 def import_font(size: int, font_path: str) -> pygame.font.Font: # Might be changed later on if we use pygame.freetype instead
     return pygame.font.Font(resource_path(font_path), size)
-
 
 def import_image(img_path: str, alpha: bool = True) -> pygame.Surface:
     full_path = resource_path(img_path)
     surf = pygame.image.load(full_path).convert_alpha() if alpha else pygame.image.load(full_path).convert()
     return pygame.transform.scale_by(surf, SCALE_FACTOR)
-
 
 def import_folder(fold_path: str) -> list[pygame.Surface]:
     frames = []
@@ -28,7 +25,6 @@ def import_folder(fold_path: str) -> list[pygame.Surface]:
             full_path = join(folder_path, file_name)
             frames.append(pygame.transform.scale_by(pygame.image.load(full_path).convert_alpha(), SCALE_FACTOR))
     return frames
-
 
 def import_folder_dict(fold_path: str) -> dict[str, pygame.Surface]:
     frames = {}
@@ -39,7 +35,6 @@ def import_folder_dict(fold_path: str) -> dict[str, pygame.Surface]:
                                                                         SCALE_FACTOR)
     return frames
 
-
 def tmx_importer(tmx_path: str) -> MapDict:
     files = {}
     for folder_path, _, file_names in walk(resource_path(tmx_path)):
@@ -47,7 +42,6 @@ def tmx_importer(tmx_path: str) -> MapDict:
             full_path = join(folder_path, file_name)
             files[file_name.split('.')[0]] = load_pygame(full_path)
     return files
-
 
 def animation_importer(*ani_path: str) -> dict[str, AniFrames]:
     animation_dict = {}
@@ -63,7 +57,6 @@ def animation_importer(*ani_path: str) -> dict[str, AniFrames]:
                 animation_dict[file_name.split('.')[0]].append(pygame.transform.scale_by(cutout_surf, SCALE_FACTOR))
     return animation_dict
 
-
 def single_character_importer(*sc_path: str) -> AniFrames:
     char_dict = {}
     full_path = join(*sc_path)
@@ -78,7 +71,6 @@ def single_character_importer(*sc_path: str) -> AniFrames:
     char_dict['right'] = [pygame.transform.flip(surf, True, False) for surf in char_dict['left']]
     return char_dict
 
-
 def character_importer(chr_path: str) -> dict[str, AniFrames]:
     # create dict with subfolders 
     for _, sub_folders, _ in walk(resource_path(chr_path)):
@@ -92,7 +84,6 @@ def character_importer(chr_path: str) -> dict[str, AniFrames]:
                 char_dict[char][file_name.split('.')[0]] = single_character_importer(join(folder_path, file_name))
     return char_dict
 
-
 def sound_importer(*snd_path: str, default_volume: float = 0.5) -> SoundDict:
     sounds_dict = {}
 
@@ -102,7 +93,6 @@ def sound_importer(*snd_path: str, default_volume: float = 0.5) -> SoundDict:
         value.set_volume(default_volume)
         sounds_dict[key] = value
     return sounds_dict
-
 
 def generate_particle_surf(img: pygame.Surface) -> pygame.Surface:
     px_mask = pygame.mask.from_surface(img)

--- a/src/support.py
+++ b/src/support.py
@@ -1,140 +1,109 @@
-import os
-import pygame
-import pytmx
-import sys
-from src import settings
-from src.settings import (
-    CHAR_TILE_SIZE,
-    SCALE_FACTOR,
-    TILE_SIZE,
-)
+from .settings import *
+from os import *
 
 
 def resource_path(relative_path: str):
     """Get absolute path to resource, works for dev and for PyInstaller"""
-    relative_path = relative_path.replace("/", os.sep)
+    relative_path = relative_path.replace("/", sep)
     try:
         base_path = sys._MEIPASS
     except Exception:
-        base_path = os.path.dirname(os.path.abspath(sys.argv[0]))
-    return os.path.join(base_path, relative_path)
+        base_path = path.dirname(path.abspath(sys.argv[0]))
+    return path.join(base_path, relative_path)
 
 
 def import_font(size: int, font_path: str) -> pygame.font.Font: # Might be changed later on if we use pygame.freetype instead
-
     return pygame.font.Font(resource_path(font_path), size)
+
 
 def import_image(img_path: str, alpha: bool = True) -> pygame.Surface:
     full_path = resource_path(img_path)
-    surf = pygame.image.load(full_path).convert_alpha(
-    ) if alpha else pygame.image.load(full_path).convert()
+    surf = pygame.image.load(full_path).convert_alpha() if alpha else pygame.image.load(full_path).convert()
     return pygame.transform.scale_by(surf, SCALE_FACTOR)
+
 
 def import_folder(fold_path: str) -> list[pygame.Surface]:
     frames = []
-    for folder_path, _, file_names in os.walk(resource_path(fold_path)):
-        for file_name in sorted(
-            file_names, key=lambda name: int(
-                name.split('.')[0])):
-            full_path = os.path.join(folder_path, file_name)
-            frames.append(pygame.transform.scale_by(
-                pygame.image.load(full_path).convert_alpha(), SCALE_FACTOR))
+    for folder_path, _, file_names in walk(resource_path(fold_path)):
+        for file_name in sorted(file_names, key=lambda name: int(name.split('.')[0])):
+            full_path = path.join(folder_path, file_name)
+            frames.append(pygame.transform.scale_by(pygame.image.load(full_path).convert_alpha(), SCALE_FACTOR))
     return frames
+
 
 def import_folder_dict(fold_path: str) -> dict[str, pygame.Surface]:
     frames = {}
-    for folder_path, _, file_names in os.walk(resource_path(fold_path)):
+    for folder_path, _, file_names in walk(resource_path(fold_path)):
         for file_name in file_names:
-            full_path = os.path.join(folder_path, file_name)
-            frames[file_name.split('.')[0]] = pygame.transform.scale_by(
-                pygame.image.load(full_path).convert_alpha(), SCALE_FACTOR)
+            full_path = path.join(folder_path, file_name)
+            frames[file_name.split('.')[0]] = pygame.transform.scale_by(pygame.image.load(full_path).convert_alpha(),
+                                                                        SCALE_FACTOR)
     return frames
 
 
 def tmx_importer(tmx_path: str) -> MapDict:
-
     files = {}
-    for folder_path, _, file_names in os.walk(resource_path(tmx_path)):
+    for folder_path, _, file_names in walk(resource_path(tmx_path)):
         for file_name in file_names:
-            full_path = os.path.join(folder_path, file_name)
-            files[file_name.split('.')[0]] = (
-                pytmx.util_pygame.load_pygame(full_path)
-            )
+            full_path = path.join(folder_path, file_name)
+            files[file_name.split('.')[0]] = pygame.load_pygame(full_path)
     return files
 
 
 def animation_importer(*ani_path: str) -> dict[str, AniFrames]:
-
     animation_dict = {}
-    for folder_path, _, file_names in os.walk(os.path.join(*ani_path)):
+    for folder_path, _, file_names in walk(path.join(*ani_path)):
         for file_name in file_names:
-            full_path = os.path.join(folder_path, file_name)
+            full_path = path.join(folder_path, file_name)
             surf = pygame.image.load(full_path).convert_alpha()
             animation_dict[file_name.split('.')[0]] = []
             for col in range(surf.get_width() // TILE_SIZE):
-                cutout_surf = pygame.Surface(
-                    (TILE_SIZE, TILE_SIZE), pygame.SRCALPHA)
-                cutout_rect = pygame.Rect(
-                    col * TILE_SIZE, 0, TILE_SIZE, TILE_SIZE)
+                cutout_surf = pygame.Surface((TILE_SIZE, TILE_SIZE), pygame.SRCALPHA)
+                cutout_rect = pygame.Rect(col * TILE_SIZE, 0, TILE_SIZE, TILE_SIZE)
                 cutout_surf.blit(surf, (0, 0), cutout_rect)
-                animation_dict[file_name.split('.')[0]].append(
-                    pygame.transform.scale_by(cutout_surf, SCALE_FACTOR))
+                animation_dict[file_name.split('.')[0]].append(pygame.transform.scale_by(cutout_surf, SCALE_FACTOR))
     return animation_dict
 
 
 def single_character_importer(*sc_path: str) -> AniFrames:
-
     char_dict = {}
-    full_path = os.path.join(*sc_path)
+    full_path = path.join(*sc_path)
     surf = pygame.image.load(full_path).convert_alpha()
     for row, dir in enumerate(['down', 'up', 'left']):
         char_dict[dir] = []
         for col in range(surf.get_width() // CHAR_TILE_SIZE):
             cutout_surf = pygame.Surface((48, 48), pygame.SRCALPHA)
-            cutout_rect = pygame.Rect(
-                col * CHAR_TILE_SIZE,
-                row * CHAR_TILE_SIZE,
-                CHAR_TILE_SIZE,
-                CHAR_TILE_SIZE)
+            cutout_rect = pygame.Rect(col * CHAR_TILE_SIZE, row * CHAR_TILE_SIZE, CHAR_TILE_SIZE, CHAR_TILE_SIZE)
             cutout_surf.blit(surf, (0, 0), cutout_rect)
-            char_dict[dir].append(
-                pygame.transform.scale_by(cutout_surf, SCALE_FACTOR))
-    char_dict['right'] = [pygame.transform.flip(
-        surf, True, False) for surf in char_dict['left']]
+            char_dict[dir].append(pygame.transform.scale_by(cutout_surf, SCALE_FACTOR))
+    char_dict['right'] = [pygame.transform.flip(surf, True, False) for surf in char_dict['left']]
     return char_dict
 
 
 def character_importer(chr_path: str) -> dict[str, AniFrames]:
     # create dict with subfolders 
     for _, sub_folders, _ in walk(resource_path(chr_path)):
-
         if sub_folders:
             char_dict = {folder: {} for folder in sub_folders}
 
     # go through all images and use single_character_importer to get the frames
     for char, frame_dict in char_dict.items():
-        for folder_path, sub_folders, file_names in os.walk(
-                os.path.join(resource_path(chr_path), char)):
+        for folder_path, sub_folders, file_names in walk(path.join(resource_path(chr_path), char)):
             for file_name in file_names:
-                char_dict[char][file_name.split('.')[0]] = (
-                    single_character_importer(
-                        os.path.join(folder_path, file_name)
-                    )
-                )
+                char_dict[char][file_name.split('.')[0]] = single_character_importer(path.join(folder_path, file_name))
     return char_dict
 
 
 def sound_importer(*snd_path: str, default_volume: float = 0.5) -> SoundDict:
-
-
     sounds_dict = {}
 
-    for sound_name in os.listdir(resource_path(os.path.join(*snd_path))):
+    for sound_name in listdir(resource_path(path.join(*snd_path))):
         key = sound_name.split('.')[0]
-        value = pygame.mixer.Sound(os.path.join(*snd_path, sound_name))
+        value = pygame.mixer.Sound(path.join(*snd_path, sound_name))
         value.set_volume(default_volume)
         sounds_dict[key] = value
     return sounds_dict
+
 
 def generate_particle_surf(img: pygame.Surface) -> pygame.Surface:
     px_mask = pygame.mask.from_surface(img)

--- a/src/timer.py
+++ b/src/timer.py
@@ -1,5 +1,5 @@
 import pygame
-
+from .settings import *
 
 class Timer:
     def __init__(self, duration, repeat=False, autostart=False, func=None):

--- a/src/transition.py
+++ b/src/transition.py
@@ -3,7 +3,6 @@ from .settings import *
 
 class Transition:
     def __init__(self, reset: Function, finish_reset: Function):
-
         # setup
         self.display_surface = pygame.display.get_surface()
         self.reset = reset


### PR DESCRIPTION
Overhauled the game state loop in main.py to simplify the update and drawing workflow of the game. This is one suggested way of re-working the game state loop. I found the original loop in main.py to be overly complicated and limited in the potential for expansion. This solution is the simplest version I could think of and makes it clear where to include new drawing and update features in the future. Having less duplicated code will benefit us in the long run by making it easier to locate functions and make changes. 

-simplified from 2 classes in main.py to 1 game class
-removed multiple duplicate initializations and variables
-set up main menu, pause menu and settings menu in match/case branches in the main game loop.
-split update functions from several classes into separate draw and update functions
-removed duplicate music being started in level.py
-combined setup functions into init on several classes as they are only ever called once and initiate variables for the entire class

-1 known error - slider in settings menu - causes large amount of lag when going through the menu. Has been commented out until a fix can be found