### PR TITLE
Docs: Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,83 @@
+name: Bug Report
+description: File a bug report.
+title: "Bug: "
+labels: ["type: bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: Describe the bug
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: |
+        #### Bug Description
+        ...
+
+        #### Expected Behavior
+        ...
+
+        #### Steps to Reproduce
+        1. ...
+        2. ...
+        3. ...
+
+        #### Additional Context
+        Add any other context about the problem here.
+    validations:
+      required: true
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: If applicable, what version of the game are you running?
+      options:
+        - 0.1.0
+      default: 0
+    validations:
+      required: false
+  - type: dropdown
+    id: aspect
+    attributes:
+      label: Which aspect(s) of the project is this bug affecting?
+      description: See [this wiki page](https://github.com/sloukit/pydew-valley-uzh/wiki/How-to-choose-labels) for more information on how to choose labels.
+      multiple: true
+      options:
+        - "area: code quality"
+        - "area: dependencies"
+        - "area: documentation"
+        - "area: publishing"
+        - game-art
+        - game-audio
+        - game-design
+        - game-level-design
+        - game-ui
+        - game-gameplay
+        - game-playtesting
+        - game-ai
+        - game-help
+        - game-story
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Please upload any relevant screenshots.
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](docs/CODE_OF_CONDUCT.md).
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discord Community
+    url: https://discord.gg/SuthU2qKaZ
+    about: Join our Discord community to ask questions, get help and report problems.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,64 @@
+name: Project Enhancement
+description: Suggest an enhancement to the project overall.
+title: "Enha: "
+labels: ["type: enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to make your suggestion!
+  - type: input
+    id: enhancement-title
+    attributes:
+      label: What would you like to see changed in one sentence?
+    validations:
+      required: true
+  - type: textarea
+    id: enhancement-body
+    attributes:
+      label: Elaborate on your suggestion above as needed.
+      placeholder: Tell us why this change is needed!
+      value: |
+        ...
+
+        <!-- Use the checklist below to track the progress of your enhancement.
+        Some entries may also become separate GitHub issues. -->
+        <!-- #### Checklist
+         - [] ...
+         - [] ...
+         -->
+    validations:
+      required: true
+  - type: dropdown
+    id: aspect
+    attributes:
+      label: Which aspect(s) of the project is this enhancement affecting?
+      description: See [this wiki page](https://github.com/sloukit/pydew-valley-uzh/wiki/How-to-choose-labels) for more information on how to choose labels.
+      multiple: true
+      options:
+        - "area: ci"
+        - "area: code quality"
+        - "area: dependencies"
+        - "area: documentation"
+        - "area: publishing"
+        - "area: testing"
+        - game-art
+        - game-audio       
+        - game-design      
+        - game-level-design
+        - game-ui          
+        - game-gameplay          
+        - game-playtesting     
+        - game-ai          
+        - game-help        
+        - game-story 
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](docs/CODE_OF_CONDUCT.md).
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,58 @@
+name: Feature Request
+description: Request a new feature to be added to the game.
+title: "Feat: "
+labels: ["type: feature request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest a new feature!
+  - type: input
+    id: feature-request-title
+    attributes:
+      label: What feature would you like to see added in one sentence?
+    validations:
+      required: true
+  - type: textarea
+    id: feature-request-body
+    attributes:
+      label: Elaborate on your request above as needed.
+      placeholder: Tell us why this feature should be added!
+      value: |
+        ...
+
+        <!-- Use the checklist below to track the progress of your feature request.
+        Some entries may also become separate GitHub issues. -->
+        <!-- #### Checklist
+         - [] ...
+         - [] ...
+         -->
+    validations:
+      required: true
+  - type: dropdown
+    id: aspect
+    attributes:
+      label: Which aspect(s) of the project is this enhancement affecting?
+      description: See [this wiki page](https://github.com/sloukit/pydew-valley-uzh/wiki/How-to-choose-labels) for more information on how to choose labels.
+      multiple: true
+      options:
+        - game-art
+        - game-audio       
+        - game-design      
+        - game-level-design
+        - game-ui          
+        - game-gameplay          
+        - game-playtesting     
+        - game-ai          
+        - game-help        
+        - game-story 
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](docs/CODE_OF_CONDUCT.md).
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE/code_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/code_pr_template.md
@@ -1,0 +1,21 @@
+<!-- Please delete or use (when it makes sense) the content within all HTML comments like this one before opening your pull request.
+No "<!--" or "--\>" should remain.
+"|" means pick any of the surrounding options. -->
+
+## Summary
+
+This PR <!-- implements|enhances|fixes  ... --> <!-- (as described in issue #... ) --> .
+
+<!-- elaborate more on the changes made, if necessary -->
+
+<!-- ## Media
+Add screenshots or videos if applicable, otherwise delete this section -->
+
+## Checklist
+
+- [ ] I have tested this change locally and it works as expected.
+- [ ] I have made sure that the code follows the formatting and style guidelines of the project.
+<!-- - [ ] Since this PR modifies related documentation, I have proofread files for spelling and grammar errors. -->
+
+## Labels
+`type: ...`, `area: ...`, `game-...`, ... <!-- Fill and expand on this line as needed. See https://github.com/sloukit/pydew-valley-uzh/wiki/How-to-choose-labels for more information. -->

--- a/.github/PULL_REQUEST_TEMPLATE/docs_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/docs_pr_template.md
@@ -1,0 +1,16 @@
+<!-- Please delete or use (when it makes sense) the content within all HTML comments like this one before opening your pull request.
+No "<!--" or "--\>" should remain.
+"|" means pick any of the surrounding options. -->
+
+## Summary
+
+This PR <!-- adds|modifies --> documentation for ... <!-- (as described in issue #... ). -->
+
+<!-- elaborate more on the changes made, if necessary -->
+
+## Checklist
+- [ ] I have proofread files for spelling and grammar errors.
+
+
+## Labels
+`type: enhancement`, `area: documentation`, ... <!-- Fill and expand on this line as needed. See https://github.com/sloukit/pydew-valley-uzh/wiki/How-to-choose-labels for more information. -->

--- a/.github/PULL_REQUEST_TEMPLATE/pr_revert_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_revert_template.md
@@ -1,0 +1,15 @@
+<!-- Please delete or use (when it makes sense) the content within all HTML comments like this one before opening your pull request.
+No "<!--" or "--\>" should remain.
+"|" means pick any of the surrounding options. -->
+
+## Summary
+This PR reverts the changes made in PR #... <!-- , because ...|in order to fix #... -->.
+
+<!-- elaborate more on the changes made, if necessary -->
+
+## Checklist
+- [ ] I have checked that my revert leaves the codebase in the same state as before the target PR.
+
+
+## Labels
+`type: ...`, `area: ...`, `game-...`, ... <!-- Fill and expand on this line as needed. See https://github.com/sloukit/pydew-valley-uzh/wiki/How-to-choose-labels for more information. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+Please go the the `Preview` tab and select the appropriate sub-template:
+
+* [Features/Enhancements/Fixes](?expand=1&template=code_pr_template.md) 
+* [Documentation](?expand=1&template=docs_pr_template.md)
+* [Reverts](?expand=1&template=pr_revert_template.md)


### PR DESCRIPTION
This PR adds GitHub issue and PR templates to help with tagging some GitHub issues ahead of time and streamlining how PRs are structured.