### PR TITLE
docs: Fix broken links and markdown issues in GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -77,7 +77,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](docs/CODE_OF_CONDUCT.md).
+      description: By submitting this issue, you agree to follow our Code of Conduct.
       options:
-        - label: I agree to follow this project's Code of Conduct
+        - label: I agree to follow this project's Code of Conduct.
           required: true

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -24,8 +24,8 @@ body:
         <!-- Use the checklist below to track the progress of your enhancement.
         Some entries may also become separate GitHub issues. -->
         <!-- #### Checklist
-         - [] ...
-         - [] ...
+         - [ ] ...
+         - [ ] ...
          -->
     validations:
       required: true
@@ -58,7 +58,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](docs/CODE_OF_CONDUCT.md).
+      description: By submitting this issue, you agree to follow our Code of Conduct.
       options:
-        - label: I agree to follow this project's Code of Conduct
+        - label: I agree to follow this project's Code of Conduct.
           required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -24,8 +24,8 @@ body:
         <!-- Use the checklist below to track the progress of your feature request.
         Some entries may also become separate GitHub issues. -->
         <!-- #### Checklist
-         - [] ...
-         - [] ...
+         - [ ] ...
+         - [ ] ...
          -->
     validations:
       required: true
@@ -52,7 +52,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](docs/CODE_OF_CONDUCT.md).
+      description: By submitting this issue, you agree to follow our Code of Conduct.
       options:
-        - label: I agree to follow this project's Code of Conduct
+        - label: I agree to follow this project's Code of Conduct.
           required: true


### PR DESCRIPTION
## Summary

This PR modifies documentation for GitHub issue templates by fixing markdown and broken links.

## Checklist
- [x] I have proofread files for spelling and grammar errors.

## Labels
`type: enhancement`, `area: documentation`
