### PR TITLE
Fixed bad filename and missing STL warnings import

### DIFF
--- a/src/import_checks.py
+++ b/src/import_checks.py
@@ -1,6 +1,6 @@
-
 import sys
 import pygame
+import warnings
 
 
 if not getattr(pygame, "IS_CE", False):

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,7 +1,7 @@
 import pygame
 import pygame.freetype
 import pytmx
-from src.warnings import *
+from src.import_checks import *
 
 type Coordinate = tuple[int | float, int | float]
 type SoundDict = dict[str, pygame.mixer.Sound]


### PR DESCRIPTION
<!-- Please delete or use (when it makes sense) the content within all HTML comments like this one before opening your pull request.
No "<!--" or "--\>" should remain.
"|" means pick any of the surrounding options. -->

## Summary

This PR fixes a bad filename (src/warnings.py) and adds back a removed STL import which was necessary to ensure the warning could be issued if a version of Python lower than 3.12 was used to run the game.

## Checklist

- [x] I have tested this change locally and it works as expected.
- [x] I have made sure that the code follows the formatting and style guidelines of the project.
