### PR TITLE
Event sys expansion

### DIFF
--- a/src/events.py
+++ b/src/events.py
@@ -1,0 +1,109 @@
+"""Expansion over Pygame's event management system."""
+import pygame
+from typing import Union, Type, NoReturn
+from types import UnionType, NoneType
+
+SpecialForm = type(NoReturn)
+
+
+class _EventDefinition:
+    """Additional information about a specific event type.
+
+    This allows us to ensure that all required arguments are given
+    when posting an event of a certain type (namely, by raising errors if they
+    aren't given)."""
+
+    _EDEF_CACHE = {}  # INTERNAL USAGE!
+    __slots__ = ("name", "__name__", "code", "attrs", "default_values_for_attrs")
+
+    @classmethod
+    def from_code(cls, code: int) -> "_EventDefinition":
+        """Return the corresponding event definition for a given code."""
+        try:
+            return cls._EDEF_CACHE[code]
+        except LookupError:
+            raise ValueError(f"given code ({code}) is not linked to a registered event type")
+
+    @classmethod
+    def add_to_edef_cache(cls, edef: "_EventDefinition"):
+        """Add the given event definition to the cache."""
+        cls._EDEF_CACHE[edef.code] = edef
+
+    def __init__(
+        self,
+        name: str,
+        code: int,
+        **attrs: Union[Type, SpecialForm],
+    ):
+        self.__name__ = self.name = name
+        self.attrs = attrs
+        self.default_values_for_attrs = {}
+        self.code = code
+
+    def __repr__(self):
+        return f"<EventDefinition(name='{self.__name__}', code={self.code}, {', '.join((f'{attr}:{value}' for attr, value in self.attrs.items()))}>"
+
+    def __hash__(self):
+        return hash(
+            (self.__name__, self.code) + tuple(itm for itm in self.attrs.items())
+        )
+
+    def set_default_for_attr(self, attr: str, value):
+        if attr not in self.attrs:
+            raise ValueError(
+                f"invalid attribute for event type {self.__name__} : '{attr}'"
+            )
+        else:
+            self.default_values_for_attrs[attr] = value
+
+    def __call__(self, **attrs):
+        if self.attrs:
+            for attr in attrs:
+                try:
+                    assert attr in self.attrs
+                except AssertionError as err:
+                    raise TypeError(
+                        f"unexpected attributes for event type '{self.__name__}'"
+                    ) from err
+            for attr, attr_type in self.attrs.items():
+                if attr in attrs:
+                    continue
+                else:
+                    if "Optional" in repr(attr_type):
+                        pass
+                    elif isinstance(attr_type, UnionType) and NoneType in attr_type.__args__:
+                        pass
+                    elif attr in self.default_values_for_attrs:
+                        attrs[attr] = self.default_values_for_attrs[attr]
+                    else:
+                        raise TypeError(
+                            f"missing argument for event type '{self.__name__}' : '{attr}'"
+                        )
+        else:
+            if attrs:
+                raise TypeError(
+                    f"event type '{self.__name__}' does not take any attributes"
+                )
+        return pygame.event.Event(self.code, **attrs)
+
+
+def get_event_def(code: int) -> _EventDefinition:
+    """Return the corresponding event type specification for the given code.
+
+    :param code: The code you wish to retrive the event specs of.
+    :return: The corresponding definition."""
+    return _EventDefinition.from_code(code)
+
+
+def create_custom_event_type(name: str, **attributes: Union[Type, SpecialForm]) -> int:
+    """Register a new event type and its specifications.
+
+    :param name: The definition name (will be used in mostly error messages).
+    :param attributes: The event's required attributes. If empty,
+    trying to add any attributes to an event of this type will result in
+    a TypeError being raised."""
+    created_code = pygame.event.custom_type()
+    edef = _EventDefinition(name, created_code, **attributes)
+    _EventDefinition.add_to_edef_cache(edef)
+    return created_code
+

--- a/src/import_checks.py
+++ b/src/import_checks.py
@@ -1,6 +1,6 @@
-
 import sys
 import pygame
+import warnings
 
 
 if not getattr(pygame, "IS_CE", False):

--- a/src/npc/npc.py
+++ b/src/npc/npc.py
@@ -14,15 +14,6 @@ import pygame
 import random
 
 
-
-_NONSEED_INVENTORY_DEFAULT_AMOUNT = 20
-_SEED_INVENTORY_DEFAULT_AMOUNT = 5
-_INV_DEFAULT_AMOUNTS = (
-    _NONSEED_INVENTORY_DEFAULT_AMOUNT,
-    _SEED_INVENTORY_DEFAULT_AMOUNT
-)
-
-
 # <editor-fold desc="NPC">
 # @dataclass
 class NPCBehaviourContext:
@@ -168,7 +159,6 @@ class NPCBehaviourMethods:
             context, random.choice(possible_coordinates), on_path_completion
         )
 
-    # FIXME: When NPCs water the plants, the hoe is displayed as the item used instead of the watering can
     # FIXME: When NPCs water the plants, the axe is displayed as the item used instead of the watering can
     @staticmethod
     def water_farmland(context: NPCBehaviourContext) -> bool:

--- a/src/screens/pause.py
+++ b/src/screens/pause.py
@@ -7,7 +7,7 @@ from src.enums import GameState
 
 class PauseMenu(GeneralMenu):
     def __init__(self, switch_screen):
-        options = ['Resume', 'Options', 'Quit']
+        options = ['Resume', 'Options', "Save and Resume", 'Quit']
         title = 'Pause Menu'
         size = (400, 400)
         super().__init__(title, options, switch_screen, size)
@@ -17,6 +17,8 @@ class PauseMenu(GeneralMenu):
             self.switch_screen(GameState.LEVEL)
         if text == 'Options':
             self.switch_screen(GameState.SETTINGS)
+        if text == "Save and Resume":
+            self.switch_screen(GameState.LEVEL)
         if text == 'Quit':
             self.quit_game()
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,7 +1,7 @@
 import pygame
 import pygame.freetype
 import pytmx
-from src.warnings import *
+from src.import_checks import *
 
 type Coordinate = tuple[int | float, int | float]
 type SoundDict = dict[str, pygame.mixer.Sound]

--- a/src/sprites/player.py
+++ b/src/sprites/player.py
@@ -1,12 +1,17 @@
 
-import pygame
+import pygame  # noqa
 from typing import Callable
 from src import settings, savefile, support
 from src.sprites.entity import Entity
 from src.enums import InventoryResource, FarmingTool, ItemToUse
 from src.settings import SCALE_FACTOR
-from src.npc.npc import _INV_DEFAULT_AMOUNTS, _SEED_INVENTORY_DEFAULT_AMOUNT, _NONSEED_INVENTORY_DEFAULT_AMOUNT
 
+_NONSEED_INVENTORY_DEFAULT_AMOUNT = 20
+_SEED_INVENTORY_DEFAULT_AMOUNT = 5
+_INV_DEFAULT_AMOUNTS = (
+    _NONSEED_INVENTORY_DEFAULT_AMOUNT,
+    _SEED_INVENTORY_DEFAULT_AMOUNT
+)
 
 
 class Player(Entity):

--- a/src/tests/test_event_expansion.py
+++ b/src/tests/test_event_expansion.py
@@ -1,0 +1,87 @@
+"""Test suite for the event queue"""
+import unittest
+import src.events
+from src.events import _EventDefinition as _EDef
+import pygame
+
+_DUMMY = object()
+pygame.init()
+
+
+class TestEventExpansion(unittest.TestCase):
+
+    def test_no_attributes(self):
+        test_event_type = src.events.create_custom_event_type("TestEventType")
+        edef = src.events.get_event_def(test_event_type)
+        self.assertDictEqual(edef.attrs, {})
+
+    def test_post_evt_no_attributes(self):
+        test_event_type = src.events.create_custom_event_type("TestEventType")
+        src.events.post_event(test_event_type)
+        edef = src.events.get_event_def(test_event_type)
+        result_event = edef()
+        self.assertDictEqual(result_event.dict, {})
+        event_queue = pygame.event.get()
+        self.assertIn(result_event, event_queue, "event was not posted")
+
+    def test_evt_type_no_attrs_posted_with_attrs(self):
+        evt_noattrs = src.events.create_custom_event_type("EventNoAttrs")
+        self.assertRaises(
+            TypeError,
+            src.events.post_event,
+            evt_noattrs,
+            some_unexpected_attribute=_DUMMY
+        )
+
+    def test_one_attribute(self):
+        expected_dict = {
+            "attr1": int
+        }
+        test_event_type = src.events.create_custom_event_type("TestEventType", attr1=int)
+        edef = src.events.get_event_def(test_event_type)
+        self.assertDictEqual(edef.attrs, expected_dict)
+
+    def test_post_evt_one_attribute_correct_value(self):
+        test_event_type = src.events.create_custom_event_type("TestEventType", attr1=int)
+        edef = src.events.get_event_def(test_event_type)
+        src.events.post_event(test_event_type, attr1=5)
+        result_event = edef(attr1=5)
+        self.assertEqual(5, result_event.attr1)
+        self.assertIn(result_event, pygame.event.get(), "event was not posted")
+
+    def test_evt_type_one_attr_wrong_type(self):
+        evt_one_attr = src.events.create_custom_event_type("EvtOneAttr", attr1=float)
+        self.assertRaises(
+            TypeError,
+            src.events.post_event,
+            evt_one_attr,
+            attr1="wrong type"
+        )
+
+    def test_evt_type_one_attr_arg_missing(self):
+        evt_one_attr = src.events.create_custom_event_type("EvtOneAttr", attr1=int)
+        self.assertRaises(
+            TypeError,
+            src.events.post_event,
+            evt_one_attr
+        )
+
+    def test_evt_type_one_attr_arg_missing_default_set(self):
+        evt_one_attr = src.events.create_custom_event_type("EvtOneAttr", attr1=int)
+        edef = src.events.get_event_def(evt_one_attr)
+        edef.set_default_for_attr("attr1", 1)
+        self.assertEqual(edef.default_values_for_attrs["attr1"], 1)
+        evt_with_default = edef()
+        self.assertEqual(evt_with_default.attr1, 1)
+        evt_custom_val = edef(attr1=6)
+        self.assertEqual(evt_custom_val.attr1, 6)
+
+    def test_evt_type_one_attr_union_type(self):
+        IntOrStr = int | str
+        evt_one_attr = src.events.create_custom_event_type("EvtOneAttr", attr1=IntOrStr)
+        edef = src.events.get_event_def(evt_one_attr)
+        self.assertIs(edef.attrs["attr1"], IntOrStr)
+        event_with_type_a_value = edef(attr1=50)
+        self.assertEquals(event_with_type_a_value.attr1, 50)
+
+

--- a/src/tests/test_event_expansion.py
+++ b/src/tests/test_event_expansion.py
@@ -5,31 +5,41 @@ from src.events import _EventDefinition as _EDef
 import pygame
 
 _DUMMY = object()
+IntOrStr = int | str
 pygame.init()
 
 
 class TestEventExpansion(unittest.TestCase):
 
+    def setUp(self):
+        try:
+            self.test_event_type = src.events.create_custom_event_type("TestEventType")
+            self.evt_one_attr = src.events.create_custom_event_type("EvtOneAttr", attr1=int)
+            self.evt_union = src.events.create_custom_event_type("EvtUnion", attr1=IntOrStr)
+            self.evt_optional = src.events.create_custom_event_type("EvtOptional", attr1=int | None)
+        except ValueError:
+            self.test_event_type = src.events.get_event_def_from_name("TestEventType").code
+            self.evt_one_attr = src.events.get_event_def_from_name("EvtOneAttr").code
+            self.evt_union = src.events.get_event_def_from_name("EvtUnion").code
+            self.evt_optional = src.events.get_event_def_from_name("EvtOptional").code
+
     def test_no_attributes(self):
-        test_event_type = src.events.create_custom_event_type("TestEventType")
-        edef = src.events.get_event_def(test_event_type)
+        edef = src.events.get_event_def(self.test_event_type)
         self.assertDictEqual(edef.attrs, {})
 
     def test_post_evt_no_attributes(self):
-        test_event_type = src.events.create_custom_event_type("TestEventType")
-        src.events.post_event(test_event_type)
-        edef = src.events.get_event_def(test_event_type)
+        src.events.post_event(self.test_event_type)
+        edef = src.events.get_event_def(self.test_event_type)
         result_event = edef()
         self.assertDictEqual(result_event.dict, {})
         event_queue = pygame.event.get()
         self.assertIn(result_event, event_queue, "event was not posted")
 
     def test_evt_type_no_attrs_posted_with_attrs(self):
-        evt_noattrs = src.events.create_custom_event_type("EventNoAttrs")
         self.assertRaises(
             TypeError,
             src.events.post_event,
-            evt_noattrs,
+            self.test_event_type,
             some_unexpected_attribute=_DUMMY
         )
 
@@ -37,38 +47,33 @@ class TestEventExpansion(unittest.TestCase):
         expected_dict = {
             "attr1": int
         }
-        test_event_type = src.events.create_custom_event_type("TestEventType", attr1=int)
-        edef = src.events.get_event_def(test_event_type)
+        edef = src.events.get_event_def(self.evt_one_attr)
         self.assertDictEqual(edef.attrs, expected_dict)
 
     def test_post_evt_one_attribute_correct_value(self):
-        test_event_type = src.events.create_custom_event_type("TestEventType", attr1=int)
-        edef = src.events.get_event_def(test_event_type)
-        src.events.post_event(test_event_type, attr1=5)
+        edef = src.events.get_event_def(self.evt_one_attr)
+        src.events.post_event(self.evt_one_attr, attr1=5)
         result_event = edef(attr1=5)
         self.assertEqual(5, result_event.attr1)
         self.assertIn(result_event, pygame.event.get(), "event was not posted")
 
     def test_evt_type_one_attr_wrong_type(self):
-        evt_one_attr = src.events.create_custom_event_type("EvtOneAttr", attr1=float)
         self.assertRaises(
             TypeError,
             src.events.post_event,
-            evt_one_attr,
+            self.evt_one_attr,
             attr1="wrong type"
         )
 
     def test_evt_type_one_attr_arg_missing(self):
-        evt_one_attr = src.events.create_custom_event_type("EvtOneAttr", attr1=int)
         self.assertRaises(
             TypeError,
             src.events.post_event,
-            evt_one_attr
+            self.evt_one_attr
         )
 
     def test_evt_type_one_attr_arg_missing_default_set(self):
-        evt_one_attr = src.events.create_custom_event_type("EvtOneAttr", attr1=int)
-        edef = src.events.get_event_def(evt_one_attr)
+        edef = src.events.get_event_def(self.evt_one_attr)
         edef.set_default_for_attr("attr1", 1)
         self.assertEqual(edef.default_values_for_attrs["attr1"], 1)
         evt_with_default = edef()
@@ -77,11 +82,35 @@ class TestEventExpansion(unittest.TestCase):
         self.assertEqual(evt_custom_val.attr1, 6)
 
     def test_evt_type_one_attr_union_type(self):
-        IntOrStr = int | str
-        evt_one_attr = src.events.create_custom_event_type("EvtOneAttr", attr1=IntOrStr)
-        edef = src.events.get_event_def(evt_one_attr)
+        edef = src.events.get_event_def(self.evt_union)
         self.assertIs(edef.attrs["attr1"], IntOrStr)
         event_with_type_a_value = edef(attr1=50)
-        self.assertEquals(event_with_type_a_value.attr1, 50)
+        self.assertEqual(event_with_type_a_value.attr1, 50)
+        event_with_type_b_value = edef(attr1="blah")
+        self.assertEqual(event_with_type_b_value.attr1, "blah")
 
+    def test_evt_type_one_attr_union_type_tp_not_in_union(self):
+        edef = src.events.get_event_def(self.evt_union)
+        self.assertRaises(
+            TypeError,
+            edef,
+            attr1=bytearray(3)
+        )
 
+    def test_evt_type_optional_one_attr_no_attr_given(self):
+        edef = src.events.get_event_def(self.evt_optional)
+        result = edef()
+        self.assertFalse(hasattr(result, "attr1"))
+
+    def test_evt_type_optional_one_attr_attr_given(self):
+        edef = src.events.get_event_def(self.evt_optional)
+        result = edef(attr1=2)
+        self.assertEqual(result.attr1, 2)
+
+    def test_evt_type_optional_wrong_type(self):
+        edef = src.events.get_event_def(self.evt_optional)
+        self.assertRaises(
+            TypeError,
+            edef,
+            attr1=3.5
+        )


### PR DESCRIPTION
## Summary

This PR expands on the event system made available by Pygame. Namely, creating custom event types allows you to typehint the different attributes one would expect when attempting to post an event of a given custom event type, and ensure that they have been given, raising an error if they weren’t.

For example, say you create a custom event type `BLAHBLAH`, and give it some attributes:


```py
BLAHBLAH = create_custom_event_type("BlahBlah", yadda=int)

post_event(BLAHBLAH)  # not OK, argument yadda missing. TypeError raised
post_event(BLAHBLAH, yadda=5) # OK, argument yadda has been given. Code proceeds. 
# Then in the event loop do whatever you want 
# with the resulting BLAHBLAH event
```

## Checklist

- [x] I have tested this change locally and it works as expected.
- [x] I have made sure that the code follows the formatting and style guidelines of the project.
- [x] Since this PR modifies related documentation, I have proofread files for spelling and grammar errors.