### PR TITLE
fix(controls): Keybind settings, Mutability of Control dataclass, docstrings

### DIFF
--- a/src/controls.py
+++ b/src/controls.py
@@ -11,14 +11,11 @@ class Control:
     """
     Instances of this dataclass refer to an individual Control / Keybind and
     its respective type, text, value and state.
-    When creating a new Control object, you should only initialise
 
     Attributes:
         control_value: Integer value of this control.
-               Should be set to one of the key constants included in PyGame
-               (see https://pyga.me/docs/ref/key.html).
-               Is not necessarily required during class instantiation
-               but should be set afterwards.
+               Should be set to one of the key / mouse button constants
+               included in PyGame (see also https://pyga.me/docs/ref/key.html).
         text: Text to describe the control (e.g. in the Settings/Keybinds menu)
 
         _default_value: Default value of the Control
@@ -51,8 +48,11 @@ class Control:
         return self._default_value
 
     def _control_as_dict(self) -> dict[str, str | int]:
-        """Returns a dictionary representation of this Control instance,
-        excluding attributes describing the current control state"""
+        """
+        Returns a dictionary representation of this Control instance, excluding
+        attributes that describe the current state of the control
+        (whether it has just been clicked or is held down)
+        """
         return_dict = {}
         for _field in fields(self):
             if _field.metadata.get("exclude"):
@@ -66,7 +66,8 @@ class Control:
         return return_dict
 
     def _control_from_dict(self, d: dict[str, str | int]):
-        """Loads a Control instance from a (partial) dictionary representation.
+        """
+        Loads a Control instance from a (partial) dictionary representation.
         Ignores entries that do not map to any field of the Control instance.
         """
         control_attribute_list = [i.name for i in fields(self)]
@@ -78,7 +79,7 @@ class Control:
 
 class Controls(Control, Enum):
     """
-    Enum which groups all necessary Control instances.
+    Enum which groups all Control instances of the game.
     """
 
     UP = (pygame.K_UP, "Move Up")
@@ -95,7 +96,8 @@ class Controls(Control, Enum):
 
     @classmethod
     def as_dict(cls) -> dict[str, dict[str, str | int]]:
-        """Maps the name of each member to the value returned by
+        """
+        Maps the name of each member to the value returned by
         member._control_as_dict()
         :return: A dictionary representation of all Controls members.
         """
@@ -106,9 +108,11 @@ class Controls(Control, Enum):
 
     @classmethod
     def from_dict(cls, d: dict[str, dict[str, str | int]]):
-        """Loads the attributes of all supplied Control dictionary
+        """
+        Loads the attributes of all supplied Control dictionary
         representations.
-        Ignores entries that do not map to any member of Controls."""
+        Ignores entries that do not map to any member of Controls.
+        """
         control_name_list = [i.name for i in cls]
 
         for control_key, control_value in d.items():
@@ -119,16 +123,18 @@ class Controls(Control, Enum):
     def load_default_keybind(
             cls, control: Self, keybinds: dict[str, int] = None
     ):
-        """Loads a singular Control.value of the given Controls member from the
+        """
+        Loads a singular Control.value of the given Controls member from the
         supplied keybinds dictionary. The name of the given Controls member
         should correspond to the dictionary key of the keybind. If there is no
         corresponding key in the keybinds dictionary, the Control.value will be
         set to None. When no keybinds are supplied, the keybinds defined in
-        DEFAULT_CONTROLS will be used."""
+        DEFAULT_CONTROLS will be used.
+        """
         if keybinds is None:
             control.control_value = control.get_default_value()
         else:
-            control.control_value = keybinds.get(control.get_name())
+            control.control_value = keybinds.get(control.name)
 
     @classmethod
     def load_default_keybinds(cls, keybinds: dict[str, int] = None):
@@ -140,10 +146,6 @@ class Controls(Control, Enum):
         """
         for control in cls:
             cls.load_default_keybind(control, keybinds=keybinds)
-
-    def get_name(self):
-        """:return: Name (_name_ attribute) of the Controls member"""
-        return self._name_
 
     @classmethod
     def all_controls(cls) -> Generator[Control, None, None]:

--- a/src/controls.py
+++ b/src/controls.py
@@ -6,7 +6,7 @@ from typing import Self
 import pygame
 
 
-@dataclass
+@dataclass(eq=False)
 class Control:
     """
     Instances of this dataclass refer to an individual Control / Keybind and

--- a/src/gui/menu/description.py
+++ b/src/gui/menu/description.py
@@ -170,6 +170,9 @@ class KeybindsDescription(Description):
             s2_pos = self.description_slider_rect.topleft
             offset = vector(s1_pos) + vector(s2_pos)
             if event.type == pygame.MOUSEBUTTONDOWN:
+                if event.button > pygame.BUTTON_RIGHT:
+                    # Scrolling should not be allowed as keybind
+                    return False
                 if self.selection_key.hover(offset):
                     rpath = resource_path('images/keys/rclick.png')
                     lpath = resource_path('images/keys/lclick.png')


### PR DESCRIPTION
## Summary

This PR fixes several minor issues of controls.py.

- fix the mouse scroll wheel being a valid option in the keybind settings
- make the Control dataclass immutable
- improve docstrings
- remove redundant method Controls.get_name


## Checklist

- [X] I have tested this change locally and it works as expected.
- [X] I have made sure that the code follows the formatting and style guidelines of the project.

## Labels
https://github.com/sloukit/pydew-valley-uzh/labels/area%3A%20code%20quality https://github.com/sloukit/pydew-valley-uzh/labels/type%3A%20bugfix
