### PR TITLE
Fix objects.tsx file

### DIFF
--- a/data/tilesets/objects.tsx
+++ b/data/tilesets/objects.tsx
@@ -113,9 +113,9 @@
   <image source="../../images/objects/weed_3.png" width="16" height="13"/>
  </tile>
  <tile id="46">
-  <image source="../../../../clear skies maps/Objects/coop_blue.png" width="30" height="42"/>
+  <image source="../../images/objects/coop_blue.png" width="30" height="42"/>
  </tile>
  <tile id="47">
-  <image source="../../../../clear skies maps/Objects/coop_green.png" width="30" height="42"/>
+  <image source="../../images/objects/coop_green.png" width="30" height="42"/>
  </tile>
 </tileset>


### PR DESCRIPTION
## Summary

This PR fixes links to the coop images in the objects.tsx file .


## Checklist

- [x] I have tested this change locally and it works as expected.

## Labels
`type: bugfix`
