### PR TITLE
fixed the day transition effect not showing up

### DIFF
--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -93,8 +93,7 @@ class Level:
         self.player = self.entities['Player']
 
         # day night cycle
-        self.transition = Transition(self.reset, self.finish_reset)
-        self.day_transition = False
+        self.day_transition = Transition(self.reset, self.finish_reset, dur=3200)
         self.current_day = 0
 
         # weather
@@ -394,8 +393,6 @@ class Level:
     def reset(self):
         self.current_day += 1
 
-        self.sky.set_time(6, 0)  # set to 0600 hours upon sleeping
-
         # plants + soil
         for tile in self.soil_layer.tiles.values():
             if tile.plant:
@@ -422,14 +419,14 @@ class Level:
 
         # sky
         self.sky.start_color = [255, 255, 255]
+        self.sky.set_time(6, 0)  # set to 0600 hours upon sleeping
 
     def finish_reset(self):
-        self.day_transition = False
         for entity in self.entities.values():
             entity.blocked = False
 
     def start_reset(self):
-        self.day_transition = True
+        self.day_transition.activate()
         for entity in self.entities.values():
             entity.blocked = True
             entity.direction = pygame.Vector2(0, 0)
@@ -444,22 +441,18 @@ class Level:
         self.all_sprites.draw(self.player.rect.center)
         self.draw_overlay()
         self.sky.display(dt)
+        self.day_transition.draw()
 
     # update
     def update_rain(self):
         if self.raining and not self.shop_active:
             self.rain.update()
 
-    def update_day(self):
-        if self.day_transition:
-            self.transition.play()
-            self.sky.set_time(6, 0)   # set to 0600 hours upon sleeping
-
     def update(self, dt: float):
         # update
         self.plant_collision()
         self.update_rain()
-        self.update_day()
+        self.day_transition.update()
         self.all_sprites.update(dt)
 
         # draw

--- a/src/support.py
+++ b/src/support.py
@@ -329,3 +329,10 @@ def get_entity_facing_direction(
     if direction[1]:
         return Direction.DOWN if direction[1] > 0 else Direction.UP
     return default_value
+
+def oscilating_lerp(a: float | int, b: float | int, t: float) -> float:
+    """returns a value smoothly iterpolated from a to b and back to a"""
+    angle =  0 + math.pi * t
+    # the sine of this range of angles (0 to pi) gives a value from 0 to 1 to 0
+    t = math.sin(angle)
+    return pygame.math.lerp(a, b, t)

--- a/src/timer.py
+++ b/src/timer.py
@@ -26,6 +26,12 @@ class Timer:
         if self.repeat:
             self.activate()
 
+    def get_progress(self) -> float:
+        """returns a value between 0 and 1 that shows the timers progress
+        1 means duration finshed"""
+        curr = pygame.time.get_ticks()
+        return (curr - self.start_time)/ self.duration if self.active else 0
+
     def update(self):
         if self.active:
             if pygame.time.get_ticks() - self.start_time >= self.duration:


### PR DESCRIPTION
## Summary
This PR fixes the day transition effect when sleeping
it was a simple draw order issue, but i noticed that the effect doesn't use delta time
so i made it work using a timer and some lerping functions 
now it works the same regardless of the fps and i added a smoothstep effect to it which looks nice

## Checklist
- [X] I have tested this change locally and it works as expected.
- [ ] I have made sure that the code follows the formatting and style guidelines of the project.

## Labels
`type: bugfix`, `area: ...`, `game-gameplay`
