### PR TITLE
re-arranged the screen overlay and modified the health bar

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ from src.settings import (
     CHAR_TILE_SIZE,
     AniFrames, MapDict, SoundDict, EMOTE_SIZE
 )
-from src.gui.health_bar import HealthProgressBar
+
 
 class Game:
     def __init__(self):
@@ -70,9 +70,6 @@ class Game:
             # GameState.LEVEL: self.level
         }
         self.current_state = GameState.MAIN_MENU
-
-        # progress bar
-        self.health_bar = HealthProgressBar(100)
 
     def switch_state(self, state: GameState):
         self.current_state = state
@@ -169,8 +166,6 @@ class Game:
             self.event_loop()
 
             self.level.update(dt)
-
-            self.health_bar.update(self.display_surface, dt)
 
             if self.game_paused():
                 self.menus[self.current_state].update(dt)

--- a/src/gui/health_bar.py
+++ b/src/gui/health_bar.py
@@ -4,52 +4,53 @@ import pygame
 from src.settings import SCALE_FACTOR
 from src.support import import_image
 
-class HealthProgressBar(pygame.sprite.Sprite):
+
+class HealthProgressBar():
     def __init__(self, hp):
-        super().__init__()
-        self.pos = (50, 60)
+        self.pos = (80, 26)
 
         # storing all three cat images
         self.cat_imgs = []
         for i in range(3):
             img = import_image(f'images/health_bar/health_cat_{i + 1}.png')
-            img = pygame.transform.scale(img, (30 * SCALE_FACTOR * 0.7, 28 * SCALE_FACTOR * 0.7))
-            rect = img.get_rect(center=(self.pos[0], self.pos[1] + 20))
+            img = pygame.transform.scale(img, (img.get_width() * 0.7,
+                                               img.get_height() * 0.7))
+            rect = img.get_rect(midright=(self.pos[0] + 10, self.pos[1] + 20))
             self.cat_imgs.append([img, rect])
-        self.curr_cat = 0 # current cat index.
+        self.curr_cat = 0  # current cat index.
 
-        # health bar
-        self.health_bar = pygame.transform.scale(import_image('images/health_bar/health_bar.png', True),
-                                                 (70 * SCALE_FACTOR * 0.8, 14 * SCALE_FACTOR * 0.8))
-        self.health_bar_rect = self.health_bar.get_rect()
-        self.health_bar_rect.topleft = self.pos
+        # health bar frame
+        self.health_bar = pygame.transform.scale(
+            import_image('images/health_bar/health_bar.png', True),
+            (70 * SCALE_FACTOR * 0.8, 14 * SCALE_FACTOR * 0.8))
+        self.health_bar_rect = self.health_bar.get_rect(topleft=self.pos)
 
         # health (inside the health bar).
         self.color = (255, 255, 255)
-        self.health = [(0, 0), (65, 0), (69, 4), (69, 9), (65, 13), (0, 13)]
-        # setting position w.r.t to self.pos
-        for i in range(len(self.health)):
-            self.health[i] = [self.pos[0] + 1 + self.health[i][0] * SCALE_FACTOR * 0.8,
-                              self.pos[1] + 1 + self.health[i][1] * SCALE_FACTOR * 0.8]
+        self.hp_rect = pygame.Rect(self.pos[0], self.pos[1],
+                                   self.health_bar.get_width(),
+                                   self.health_bar.get_height())
+        self.hp_rect.inflate_ip(0, -16)
 
         # health points
-        self.hp = hp # health points
+        self.hp = hp  # health points
+        self.max_hp = hp
         # self.per_width_hp will be substract / added as per intensity.
-        self.per_width_hp = self.health_bar_rect.width / self.hp
 
         # shake
         self.SHAKE_INTENSITY = 1.5
 
         # colors for health bar.
         self.colors = {
-            'Red': pygame.Color(255, 0, 0),
-            'Yellow': pygame.Color(255, 255, 0),
-            'Green': pygame.Color(0, 255, 0),
+            'Red': pygame.Color(210, 0, 55),
+            'Yellow': pygame.Color(253, 253, 144),
+            'Green': pygame.Color(201, 255, 117),
         }
 
     def render(self, screen):
-        health_percent = (self.health[1][0] - self.pos[0]) / self.health_bar_rect.width
-        if health_percent <= 0.25:
+        health_percent = (self.hp / self.max_hp)
+        # shake
+        if health_percent <= 0.3:
             offset = (random.uniform(-1, 1) * self.SHAKE_INTENSITY,
                       random.uniform(-1, 1) * self.SHAKE_INTENSITY)
         else:
@@ -62,39 +63,43 @@ class HealthProgressBar(pygame.sprite.Sprite):
             self.curr_cat = 1
         else:
             self.curr_cat = 2
-        pygame.draw.polygon(screen, self.color, [(coord[0] + offset[0], coord[1] + offset[1]) for coord in self.health])
-        screen.blit(self.health_bar, (self.health_bar_rect.x + offset[0], self.health_bar_rect.y + offset[1]))
+
+        # drawing
+        # health
+        self.hp_rect.width = health_percent * self.health_bar_rect.width
+        pygame.draw.rect(screen, self.color,
+                         self.hp_rect.move(offset[0], offset[1]),
+                         border_top_right_radius=12,
+                         border_bottom_right_radius=12)
+        # frame
+        screen.blit(self.health_bar, (self.health_bar_rect.x + offset[0],
+                                      self.health_bar_rect.y + offset[1]))
+        # emote
         cat_img, cat_rect = self.cat_imgs[self.curr_cat]
         screen.blit(cat_img, (cat_rect.x + offset[0], cat_rect.y + offset[1]))
 
     def apply_damage(self, intensity):
-        if self.health[1][0] > self.health_bar_rect.left:
-            for points in self.health[1:-1]:
-                points[0] -= intensity * self.per_width_hp
-            self.hp -= intensity
-        else:
-            self.health[1][0] = self.health_bar_rect.left
-            self.health[4][0] = self.health_bar_rect.left
+        self.hp = pygame.math.clamp(self.hp - intensity, 0, self.max_hp)
 
     def apply_health(self, intensity):
-        # - 3 to hide the pixels from extending health bar container.
-        if self.health[2][0] < self.health_bar_rect.right - 3:
-            for points in self.health[1:-1]:
-                points[0] += intensity * self.per_width_hp
-            self.hp += intensity
-        else:
-            self.health[2][0] = self.health_bar_rect.right - 3
-            self.health[3][0] = self.health_bar_rect.right - 3
+        self.hp = pygame.math.clamp(self.hp + intensity, 0, self.max_hp)
 
     def change_color(self):
-        health_percent = abs((self.health[1][0] - self.pos[0]) / self.health_bar_rect.width)
-        if health_percent > 0.5:
-            factor = (health_percent - 0.5) * 2
-            self.color = self.colors['Yellow'].lerp(self.colors['Green'], factor)
+        t = (self.hp / self.max_hp)
+        if t >= 0.5:
+            factor = 1 - (t - 0.5) * 2
+            self.color = self.colors['Green'].lerp(self.colors['Yellow'],
+                                                   factor**1.5)
         else:
-            factor = health_percent * 2
-            self.color = self.colors['Red'].lerp(self.colors['Yellow'], factor)
+            factor = t * 2
+            self.color = self.colors['Red'].lerp(self.colors['Yellow'],
+                                                 factor)
 
-    def update(self, screen, dt):
+    def draw(self, screen):
         self.change_color()
         self.render(screen)
+        keys = pygame.key.get_pressed()
+        if keys[pygame.K_2]:
+            self.apply_health(1)
+        elif keys[pygame.K_1]:
+            self.apply_damage(1)

--- a/src/overlay/overlay.py
+++ b/src/overlay/overlay.py
@@ -1,6 +1,6 @@
 import pygame
 from src.settings import OVERLAY_POSITIONS
-
+from src.gui.health_bar import HealthProgressBar
 
 class Overlay:
     def __init__(self, entity, overlay_frames):
@@ -12,23 +12,31 @@ class Overlay:
         # imports
         self.overlay_frames = overlay_frames
 
-    def display(self, time):
+        # ui objects
+        self.health_bar = HealthProgressBar(100)
 
-        # tool
-        tool_surf = self.overlay_frames[self.player.get_current_tool_string()]
-        tool_rect = tool_surf.get_frect(midbottom=OVERLAY_POSITIONS['tool'])
-        self.display_surface.blit(tool_surf, tool_rect)
+    def display(self, time):
 
         # seeds
         seed_surf = self.overlay_frames[self.player.get_current_seed_string()]
         seed_rect = seed_surf.get_frect(midbottom=OVERLAY_POSITIONS['seed'])
         self.display_surface.blit(seed_surf, seed_rect)
 
+        # tool
+        tool_surf = self.overlay_frames[self.player.get_current_tool_string()]
+        tool_rect = tool_surf.get_frect(midbottom=OVERLAY_POSITIONS['tool'])
+        self.display_surface.blit(tool_surf, tool_rect)
+
         # clock
         font = pygame.font.SysFont('Arial', 30)  # font/size is temporary
+        # if hours are less than 10, add a 0 to stay in the hh:mm format
+        hours = str(time[0]).rjust(2, "0")
+        # if minutes are less than 10, add a 0 to stay in the hh:mm format
+        minutes = str(time[1]).rjust(2, "0")
 
-        hours = str(time[0]).rjust(2, "0")  # if hours are less than 10, add a 0 to stay in the hh:mm format
-        minutes = str(time[1]).rjust(2, "0")  # if minutes are less than 10, add a 0 to stay in the hh:mm format
+        text_surface = font.render(f"{hours}:{minutes}", False, 'white')
+        text_rect = text_surface.get_rect(topright=OVERLAY_POSITIONS['clock'])
+        self.display_surface.blit(text_surface, text_rect)
 
-        text_surface = font.render(f"{hours}:{minutes}", False, (255, 255, 255))
-        self.display_surface.blit(text_surface, (10, 10))
+        # health bar
+        self.health_bar.draw(self.display_surface)

--- a/src/settings.py
+++ b/src/settings.py
@@ -28,8 +28,9 @@ EMOTE_SIZE = 48
 GROW_SPEED = {'corn': 1, 'tomato': 0.7}
 
 OVERLAY_POSITIONS = {
-    'tool': (40, SCREEN_HEIGHT - 15),
-    'seed': (70, SCREEN_HEIGHT - 5)}
+    'tool': (79, 150),
+    'seed': (47, 142),
+    'clock': (SCREEN_WIDTH - 10, 10)}
 
 APPLE_POS = {
     'small': [(18, 17), (30, 37), (12, 50), (30, 45), (20, 30), (30, 10)],


### PR DESCRIPTION
## Summary
This PR enhances the overlay layout and modified the health bar a bit

i included the health bar in the overlay instead of main
this means it will be affected by the color changes caused by the sky and the day transition effect
also modified the color lerping functions a bit and fixed some issues with the emotes hiding a large part 
of the health bar
i also changed the drawing order for the seed and tools in the overlay since seeds are bigger now

## Media
![image](https://github.com/user-attachments/assets/3ff9a77d-8601-44df-8a84-eaca493468d8)

## Checklist
- [X] I have tested this change locally and it works as expected.
- [X] I have made sure that the code follows the formatting and style guidelines of the project.

## Labels
`type: enhancement`, `type: bugfix`, `game-ui`
