### PR TITLE
fix: Dialogues and Entity axe hitboxes

### DIFF
--- a/src/gui/interface/dialog.py
+++ b/src/gui/interface/dialog.py
@@ -1,4 +1,5 @@
 from src.enums import Layer
+from src.sprites.base import Sprite
 from src.support import resource_path
 from src.settings import CHARS_PER_LINE, TB_SIZE, SCREEN_WIDTH, SCREEN_HEIGHT
 from src.timer import Timer
@@ -9,7 +10,7 @@ from operator import attrgetter
 import textwrap
 
 
-class TextBox(pygame.sprite.Sprite):
+class TextBox(Sprite):
     """Text box sprite that contains a part of text."""
     _TXT_SURF_EXTREMITIES: tuple[pygame.Rect, pygame.Rect] = (pygame.Rect(0, 0, 14, 202), pygame.Rect(373, 0, 18, 202))
     _TXT_SURF_REGULAR_AREA: pygame.Rect = pygame.Rect(14, 0, 1, 202)
@@ -40,15 +41,13 @@ class TextBox(pygame.sprite.Sprite):
         :param character_name: The character meant to speak using this text box.
         :param text: The dialogue the character is supposed to say.
         :param font: The font used to render this dialogue."""
-        super().__init__()
-        self.z: int = Layer.TEXT_BOX
         self.font: pygame.Font = font
         self.cname: str = character_name
         self.text: str = textwrap.fill(text, width=CHARS_PER_LINE)
         self.image: pygame.Surface = pygame.Surface(TB_SIZE, flags=pygame.SRCALPHA)
         self.__prepare_image()
         self._tmp_img: pygame.Surface = self._TB_IMAGE.copy()
-        cname: pygame.Surface = self.font.render(self.cname, True, color=pygame.Color("black"))
+        cname: pygame.Surface = self.font.render(character_name, True, color=pygame.Color("black"))
         cname_rect: pygame.Rect = cname.get_rect(center=self._CNAME_SURF_RECT.center)
         self._tmp_img.blit(cname, cname_rect)
         self._fin_img: pygame.Surface = self.image
@@ -57,7 +56,12 @@ class TextBox(pygame.sprite.Sprite):
         self._finished_advancing: bool = False
         self._txt_needs_rerender: bool = True
         self._chr_index: int = 1
-        self.rect: pygame.FRect = self.image.get_frect(bottom=SCREEN_HEIGHT, centerx=(SCREEN_WIDTH // 2))
+
+        super().__init__(
+            (SCREEN_WIDTH / 2 - self.image.width / 2,
+             SCREEN_HEIGHT - self.image.height),
+            self.image, tuple(), z=Layer.TEXT_BOX, name=character_name
+        )
 
     @property
     def finished_advancing(self):
@@ -99,7 +103,7 @@ class TextBox(pygame.sprite.Sprite):
             self._prerender_text_ani()
 
     def __prepare_image(self):
-        cname = self.font.render(self.cname, True, color=pygame.Color("black"))
+        cname = self.font.render(self.name, True, color=pygame.Color("black"))
         cname_rect = cname.get_rect(center=self._CNAME_SURF_RECT.center)
         text_surf = self.font.render(self.text, True, color=pygame.Color("black"))
         text_rect = text_surf.get_rect(topleft=(15, 78))

--- a/src/sprites/entities/entity.py
+++ b/src/sprites/entities/entity.py
@@ -67,16 +67,16 @@ class Entity(CollideableSprite, ABC):
 
     def _update_axe_hitbox(self):
         match self.facing_direction:
-            case "down":
+            case Direction.DOWN:
                 self.axe_hitbox.x = self.rect.centerx - 24
                 self.axe_hitbox.y = self.rect.centery + 24
-            case "up":
+            case Direction.UP:
                 self.axe_hitbox.x = self.rect.centerx - 8
                 self.axe_hitbox.bottom = self.rect.centery - 24
-            case "left":
+            case Direction.LEFT:
                 self.axe_hitbox.right = self.rect.centerx - 16
                 self.axe_hitbox.y = self.rect.centery + 8
-            case "right":
+            case Direction.RIGHT:
                 self.axe_hitbox.x = self.rect.centerx + 16
                 self.axe_hitbox.y = self.rect.centery + 8
 


### PR DESCRIPTION
## Summary

This PR fixes Dialogues and Entity axe hitboxes.

- dialog.TextBox now inherits from sprites.base.Sprite
- Entity._update_axe_hitbox now sets the hitbox based on a Direction enum member instead of string values

## Checklist

- [X] I have tested this change locally and it works as expected.
- [X] I have made sure that the code follows the formatting and style guidelines of the project.

## Labels
https://github.com/sloukit/pydew-valley-uzh/labels/type%3A%20bugfix
