### PR TITLE
enha(ci,dependencies): Use `ruff` instead of `black` and `flake8` for formatting/linting

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -7,46 +7,45 @@ on:
     branches: [main]
 
 jobs:
-  lint:
+  style-lint:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
 
-    - name: Install lint dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt
-        pip install tox
+      - name: Install lint dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+          pip install tox
 
-    - name: Check code style
-      run: |
-        black --check .
-        tox -e style
+      - name: Check code style and lint with Ruff
+        run: |
+          tox -e ruff
 
   test:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
 
-    - name: Install test dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements-test.txt
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-test.txt
 
-    - name: Run tests
-      run: |
-        tox -e py312
+      - name: Run tests
+        run: |
+          tox -e py312

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,78 +6,88 @@
 name = "pydew-valley-uzh"
 version = "0.1.0"
 authors = [
-    { name = "Sophie Kittelberger", email = "s.kittelberger@psychologie.uzh.ch" },
-    { name = "larsbutler" },
-    { name = "bromeon" },
-    { name = "novial" },
-    { name = "fortwoone" },
-    { name = "richkdev" },
-    { name = "pmp-p" },
-    { name = "bydariogamer" },
-    { name = "Brody Epstein" },
-    { name = "Danilo Saiu" },
-    { name = "TMN-SGR" },
-    { name = "Adrienne Bradley" },
-    { name = "farg-eh" },
-    { name = "nteinert2005" },
-    { name = "Evelin Toth" },
-    { name = "Leon" },
-    { name = "MortalCoder" },
-    { name = "asterli6" },
-    { name = "dee-a-go" },
+  { name = "Sophie Kittelberger", email = "s.kittelberger@psychologie.uzh.ch" },
+  { name = "larsbutler" },
+  { name = "bromeon" },
+  { name = "novial" },
+  { name = "fortwoone" },
+  { name = "richkdev" },
+  { name = "pmp-p" },
+  { name = "bydariogamer" },
+  { name = "Brody Epstein" },
+  { name = "Danilo Saiu" },
+  { name = "TMN-SGR" },
+  { name = "Adrienne Bradley" },
+  { name = "farg-eh" },
+  { name = "nteinert2005" },
+  { name = "Evelin Toth" },
+  { name = "Leon" },
+  { name = "MortalCoder" },
+  { name = "asterli6" },
+  { name = "dee-a-go" },
 ]
 description = "A game based on Pydeew Valley by ClearCode, used by the University of Zurich in an experimental study in psychology."
 
-[tool.black]
+# Use Ruff to replace Black, isort, and Flake8
+[tool.ruff]
 line-length = 88
-target-version = ['py312']
-include = '\.pyi?$'
-extend-exclude = '''
-# A regex preceded with ^/ will apply only to files and directories
-# in the root of the project.
-^/main.py
-'''
-exclude = '''
-(
-  /(
-      \.eggs         # exclude a few common directories in the
-    | \.git          # root of the project
-    | \.hg
-    | \.mypy_cache
-    | \.tox
-    | \.venv
-    | _build
-    | buck-out
-    | build
-    | dist
-  )/
-)
-'''
+target-version = "py312"
 
-[tool.isort]
-profile = "black"
-line_length = 88
+[tool.ruff.lint]
+select = [
+  "E", # pycodestyle errors
+  "W", # pycodestyle warnings
+  "F", # pyflakes
+  "C", # flake8-comprehensions
+  "B", # flake8-bugbear
+]
+ignore = [
+  "E501", # line too long, handled by ruff format
+  "B008", # do not perform function calls in argument defaults
+  "B028", # No explicit `stacklevel` keyword argument found (?)
+  "C901", # too complex
+]
+
+unfixable = ["B"] # Don't bother trying to fix flake8-bugbear
+
+# Ignore `E402` (import violations) in all `__init__.py` files, and in select subdirectories.
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["E402"]
+"**/{tests,docs,tools}/*" = ["E402"]
 
 
 [tool.tox]
 legacy_tox_ini = """
 [tox]
 minversion = 4.16.0
-envlist = py312,style
+envlist = py312,format,lint,tests
 
 [testenv]
-skip_installi = True
+skip_install = True
 install_command = pip install -U {opts} {packages}
 setenv = VIRTUAL_ENV={envdir}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/requirements-test.txt
        -r{toxinidir}/requirements-dev.txt
 
-# TODO: add test invocation
-allowlist_externals=echo,flake8
-commands=echo "TODO: add tests"
-# commands = pytest src --doctest-modules
+[testenv:tests]
+deps =
+    {[testenv]deps}
+    pytest
+commands = pytest src --doctest-modules
 
-[testenv:style]
-commands = flake8 main.py src
+[testenv:format]
+deps = ruff
+commands = ruff format --check .
+
+[testenv:lint]
+deps = ruff
+commands = ruff check .
+
+[testenv:ruff]
+description = Run Ruff for linting and formatting
+deps = ruff
+commands =
+    ruff format --check .
+    ruff check .
 """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,1 @@
-black~=24.4
-flake8~=7.1
-isort~=5.13
+ruff~=0.5


### PR DESCRIPTION
## Summary

This PR supersedes parts of PR #100 by replacing [`black`](https://black.readthedocs.io/), [`isort`](https://pycqa.github.io/isort/) and [`flake8`](https://flake8.pycqa.org/) with [`ruff`](https://docs.astral.sh/ruff/).

`ruff` is faster, easier to configure and implements everything they offer that we would ever need.

## Checklist

- [x] I have tested this change locally and it works as expected.
- [ ] I have made sure that the code follows the formatting and style guidelines of the project. (Ruff won't be used in this PR.)

## Labels
https://github.com/sloukit/pydew-valley-uzh/labels/type%3A%20enhancement, https://github.com/sloukit/pydew-valley-uzh/labels/area%3A%20ci, https://github.com/sloukit/pydew-valley-uzh/labels/area%3A%20code%20quality
