### PR TITLE
Add `formatlint.py` script to simplify running `ruff ...`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,11 +22,17 @@ We use [Ruff](https://docs.astral.sh/ruff/) for linting and formatting. Run `pip
 <--! The bold text above can be put into a GitHub markdown info callout like this: -->
 
 > [!IMPORTANT]
-> **Before opening a PR, please run the following commands to ensure that your code is formatted and doesn't upset the Ruff linter:**
+> **Before opening a PR, please run the following command to ensure that your code is formatted and doesn't upset the Ruff linter:**
 > 
->```sh
-> ruffformat . && ruff check --include I --fix . #  format code and sort imports
->ruff check . # Run linting and perform fixes accordingly, or use '# noqa: <RULE>' followed by a comment justifying why the rule > is ignored
+> ```sh
+> python formatlint.py
+> ```
+> 
+> Or alternatively, run the following commands individually:
+> 
+> ```sh
+> ruff format . && ruff check --include I --fix . #  format code and sort imports
+> ruff check . # Run linting and perform fixes accordingly, or use '# noqa: <RULE>' followed by a comment justifying why the rule is ignored
 > ```
 
 ## Adding new Assets

--- a/README.md
+++ b/README.md
@@ -46,14 +46,20 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for more information on how contributio
 
 ### Linting and Formatting
 
-We use [Ruff](https://docs.astral.sh/ruff/) for linting and formatting. Run `pip install -r requirements-dev.txt` to install it and other relevant dev dependencies.
+We use [Ruff](https://docs.astral.sh/ruff/) for linting and formatting. Run `pip install -r requirements-dev.txt` to install it and other relevant dependencies.
 
 > [!IMPORTANT]
-> **Before opening a PR, please run the following commands to ensure that your code is formatted and doesn't upset the Ruff linter:**
+> **Before opening a PR, please run the following command to ensure that your code is formatted and doesn't upset the Ruff linter:**
 > 
->```sh
-> ruffformat . && ruff check --include I --fix . #  format code and sort imports
->ruff check . # Run linting and perform fixes accordingly, or use '# noqa: <RULE>' followed by a comment justifying why the rule > is ignored
+> ```sh
+> python formatlint.py
+> ```
+> 
+> Or alternatively, run the following commands individually:
+> 
+> ```sh
+> ruff format . && ruff check --include I --fix . #  format code and sort imports
+> ruff check . # Run linting and perform fixes accordingly, or use '# noqa: <RULE>' followed by a comment justifying why the rule is ignored
 > ```
 
 ## Contributing

--- a/formatlint.py
+++ b/formatlint.py
@@ -1,0 +1,78 @@
+import os
+import subprocess
+import sys
+
+# Define ANSI escape codes for colors
+GRAY = "\033[90m"
+RED = "\033[91m"
+GREEN = "\033[92m"
+RESET = "\033[0m"
+
+# Define the commands to be run
+commands = [
+    ("ruff format .", "Formatting"),
+    ("ruff check --select I --fix .", "Sorting imports"),
+    ("ruff check .", "Linting"),
+]
+
+
+def run_command(command, description, index):
+    print(f"{GRAY}┌── {description} [{command}]{RESET}")
+    process = subprocess.Popen(
+        command,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=1,
+        universal_newlines=True,
+    )
+    assert process.stdout is not None
+
+    while True:
+        output = process.stdout.readline()
+        if output == "" and process.poll() is not None:
+            break
+        if output:
+            sys.stdout.write(f"{GRAY}│   >{RESET} {output}")
+            sys.stdout.flush()
+
+    # Read any remaining output after the process has completed
+    remaining_output = process.stdout.read()
+    if remaining_output:
+        for line in remaining_output.splitlines():
+            print(f"{GRAY}│   >{RESET} " + line)
+
+    return_code = process.poll()
+
+    if return_code == 0:
+        print(
+            f"{GRAY}└── {GREEN}{description} [{command}] completed successfully.{RESET}"
+        )
+    else:
+        print(
+            f"{GRAY}└── {RED}{description} [{command}] failed with return code {return_code}.{RESET}"
+        )
+
+    return return_code
+
+
+def main():
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    os.chdir(script_dir)
+    print(f"{GRAY}Running Scripts:{RESET}\n")
+
+    for i, (command, description) in enumerate(commands):
+        return_code = run_command(command, description, i)
+        if i < len(commands) - 1:
+            print()
+        if return_code != 0:
+            break
+
+    if return_code == 0:
+        print(f"\n{GRAY}{GREEN}Scripts run successfully.{RESET}")
+    else:
+        print(f"\n{GRAY}{RED}A script failed with return code {return_code}.{RESET}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR adds a script called `formatlint.py` that makes running Ruff on the codebase as easy as possible:

```sh
python formatlint.py
```

## Media
This is some example output of `python formatlint.py`:
![This is some example output of `python formatlint.py`](https://github.com/user-attachments/assets/a5a7753b-6681-44db-90a8-08368866ac87)

## Checklist

- [x] I have tested this change locally and it works as expected.
- [x] I have made sure that the code follows the formatting and style guidelines of the project.
- [x] Since this PR modifies related documentation, I have proofread files for spelling and grammar errors. -->

## Labels
https://github.com/sloukit/pydew-valley-uzh/labels/type%3A%20enhancement, https://github.com/sloukit/pydew-valley-uzh/labels/area%3A%20code%20quality, https://github.com/sloukit/pydew-valley-uzh/labels/area%3A%20documentation
