### PR TITLE
fix(GameMap, show hitboxes)

### DIFF
--- a/src/map_objects.py
+++ b/src/map_objects.py
@@ -17,18 +17,22 @@ class MapObjectType:
 class MapObjects:
     _objects: dict[int, MapObjectType]
 
+    _tilemap: TiledMap
+
     def __init__(self, tilemap: TiledMap):
+        self._tilemap = tilemap
+
         self._objects = {}
-        for gid, hitbox_list in tilemap.get_tile_colliders():
+        for gid, hitbox_list in self._tilemap.get_tile_colliders():
             map_object = MapObjectType(gid=gid)
 
-            map_object.image = tilemap.get_tile_image_by_gid(gid)
+            map_object.image = self._tilemap.get_tile_image_by_gid(gid)
             if len(hitbox_list) > 0:
                 hitbox = hitbox_list[0]
                 map_object.hitbox = pygame.FRect(
-                    hitbox.x * SCALE_FACTOR,
+                    hitbox.x * SCALE_FACTOR,  # noqa
                     hitbox.y * SCALE_FACTOR,  # noqa
-                    hitbox.width * SCALE_FACTOR,
+                    hitbox.width * SCALE_FACTOR,  # noqa
                     hitbox.height * SCALE_FACTOR,  # noqa
                 )
             else:
@@ -39,8 +43,16 @@ class MapObjects:
         try:
             return self._objects[gid]
         except KeyError as e:
-            raise SyntaxError(
+            raise KeyError(
                 f"No object with gid {gid}.\nCheck if you "
                 f"defined a valid hitbox on the object you "
                 f"tried to access."
             ) from e
+
+    def get(self, gid):
+        try:
+            return self._objects[gid]
+        except KeyError:
+            return MapObjectType(
+                gid=gid, image=self._tilemap.get_tile_image_by_gid(gid)
+            )

--- a/src/map_objects.py
+++ b/src/map_objects.py
@@ -51,9 +51,5 @@ class MapObjects:
 
     def get(self, gid):
         return self._objects.get(
-            gid,
-            MapObjectType(
-                gid=gid,
-                image=self._tilemap.get_tile_image_by_gid(gid)
-            )
+            gid, MapObjectType(gid=gid, image=self._tilemap.get_tile_image_by_gid(gid))
         )

--- a/src/map_objects.py
+++ b/src/map_objects.py
@@ -50,9 +50,10 @@ class MapObjects:
             ) from e
 
     def get(self, gid):
-        try:
-            return self._objects[gid]
-        except KeyError:
-            return MapObjectType(
-                gid=gid, image=self._tilemap.get_tile_image_by_gid(gid)
+        return self._objects.get(
+            gid,
+            MapObjectType(
+                gid=gid,
+                image=self._tilemap.get_tile_image_by_gid(gid)
             )
+        )

--- a/src/npc/setup.py
+++ b/src/npc/setup.py
@@ -14,11 +14,11 @@ class AIData:
 
     player: Player = None
 
-    _setup: bool = False
+    setup: bool = False
 
     @classmethod
     def update(cls, pathfinding_matrix: list[list[int]], player: Player) -> None:
-        if not cls._setup:
+        if not cls.setup:
             NPCBase.pf_finder = AStarFinder()
             ChickenBase.pf_finder = AStarFinder(
                 diagonal_movement=DiagonalMovement.only_when_no_obstacle
@@ -27,7 +27,7 @@ class AIData:
                 diagonal_movement=DiagonalMovement.only_when_no_obstacle
             )
 
-            cls._setup = True
+            cls.setup = True
 
         cls.Matrix = pathfinding_matrix
         cls.Grid = Grid(matrix=cls.Matrix)

--- a/src/screens/game_map.py
+++ b/src/screens/game_map.py
@@ -9,7 +9,7 @@ from pytmx import TiledElement, TiledMap, TiledObject, TiledObjectGroup, TiledTi
 from src.enums import FarmingTool, InventoryResource, Layer
 from src.groups import AllSprites, PersistentSpriteGroup
 from src.gui.interface.emotes import NPCEmoteManager, PlayerEmoteManager
-from src.map_objects import MapObjects
+from src.map_objects import MapObjects, MapObjectType
 from src.npc.bases.animal import Animal
 from src.npc.behaviour.chicken_behaviour_tree import ChickenBehaviourTree
 from src.npc.behaviour.cow_behaviour_tree import (
@@ -169,6 +169,9 @@ class GameMap:
         frames: dict,
     ):
         self._tilemap = tilemap
+
+        if "Player" not in self._tilemap.layernames:
+            raise InvalidMapError("No Player layer could be found")
 
         self.player_exit_warps = player_exit_warps
 
@@ -340,86 +343,75 @@ class GameMap:
         if SETUP_PATHFINDING:
             self._add_pf_matrix_collision((obj.x, obj.y), (obj.width, obj.height))
 
-    def _setup_collideable_object(
+    def _setup_tree(
+        self, pos: tuple[int, int], obj: TiledObject, object_type: MapObjectType
+    ):
+        props = obj.properties
+        if props.get("size") == "medium" and props.get("breakable"):
+            fruit = props.get("fruit_type")
+            if fruit == "no_fruit":
+                fruit_type, fruit_frames = None, None
+            else:
+                fruit_type = InventoryResource.from_serialised_string(fruit)
+                fruit_frames = self.frames["level"]["objects"][fruit]
+            stump_frames = self.frames["level"]["objects"]["stump"]
+
+            tree = Tree(
+                pos,
+                object_type,
+                (self.all_sprites, self.collision_sprites, self.tree_sprites),
+                obj.name,
+                fruit_frames,
+                fruit_type,
+                stump_frames,
+                self.drops_manager,
+            )
+            # we need a tree surf without fruits
+            tree.image = self.frames["level"]["objects"]["tree"]
+            tree.surf = tree.image
+
+    def _setup_map_object(
         self,
         pos: tuple[int, int],
         obj: TiledObject,
         layer: Layer,
-        groups: tuple[pygame.sprite.Group, ...] | pygame.sprite.Group,
     ):
         """
         Create a new collideable Sprite from the given TiledObject.
-        If this map's MapObjects instance doesn't contain this object's GID,
-        this method will raise an exception
-        """
-        object_type = self._map_objects[obj.gid]
-
-        CollideableMapObject(pos, object_type, z=layer).add(groups)
-
-        if SETUP_PATHFINDING:
-            self._add_pf_matrix_collision(
-                (
-                    obj.x + object_type.hitbox.x / SCALE_FACTOR,
-                    obj.y + object_type.hitbox.y / SCALE_FACTOR,
-                ),
-                (
-                    object_type.hitbox.width / SCALE_FACTOR,
-                    object_type.hitbox.height / SCALE_FACTOR,
-                ),
-            )
-
-    def _setup_tree_object(
-        self,
-        pos: tuple[int, int],
-        obj: TiledObject,
-        groups: tuple[pygame.sprite.Group, ...] | pygame.sprite.Group,
-    ):
-        """
-        Create a new collideable Sprite from the given TiledObject.
-        This Sprite will be created from the Tree class and will take the apple
-        and stump assets from self.frames
+        If the value of the object's "type" property equals "tree", this Sprite will be
+        created from the Tree class and will take its assets from self.frames
         :param pos: Position of Sprite (x, y)
-        :param obj: TiledObject to create the Tree from
-                    (the obj.image will be used as Tree image)
-        :param groups: Groups the Sprite should be added to
+        :param obj: TiledObject to create the Sprite from
+        :param layer: z-Layer on which the Sprite should be displayed
+                      (Trees will always be rendered on Layer.MAIN)
         """
-        object_type = self._map_objects[obj.gid]
+        object_type = self._map_objects.get(obj.gid)
         props = obj.properties
-        if props.get("type") == "tree":
-            if props.get("size") == "medium" and props.get("breakable"):
-                fruit = props.get("fruit_type")
-                if fruit == "no_fruit":
-                    fruit_type, fruit_frames = None, None
-                else:
-                    fruit_type = InventoryResource.from_serialised_string(fruit)
-                    fruit_frames = self.frames["level"]["objects"][fruit]
-                stump_frames = self.frames["level"]["objects"]["stump"]
 
-                tree = Tree(
-                    pos,
-                    object_type,
-                    (self.all_sprites, self.collision_sprites, self.tree_sprites),
-                    obj.name,
-                    fruit_frames,
-                    fruit_type,
-                    stump_frames,
-                    self.drops_manager,
-                )
-                # we need a tree surf without fruits
-                tree.image = self.frames["level"]["objects"]["tree"]
-                tree.surf = tree.image
-
-                if SETUP_PATHFINDING:
-                    self._add_pf_matrix_collision(
-                        (
-                            obj.x + object_type.hitbox.x / SCALE_FACTOR,
-                            obj.y + object_type.hitbox.y / SCALE_FACTOR,
-                        ),
-                        (
-                            object_type.hitbox.width / SCALE_FACTOR,
-                            object_type.hitbox.height / SCALE_FACTOR,
-                        ),
+        if object_type.hitbox is not None:
+            if props.get("type") == "tree":
+                self._setup_tree(pos, obj, object_type)
+            else:
+                if object_type.hitbox is not None:
+                    CollideableMapObject(pos, object_type, z=layer).add(
+                        self.all_sprites,
+                        self.collision_sprites,
                     )
+
+            if SETUP_PATHFINDING:
+                self._add_pf_matrix_collision(
+                    (
+                        obj.x + object_type.hitbox.x / SCALE_FACTOR,
+                        obj.y + object_type.hitbox.y / SCALE_FACTOR,
+                    ),
+                    (
+                        object_type.hitbox.width / SCALE_FACTOR,
+                        object_type.hitbox.height / SCALE_FACTOR,
+                    ),
+                )
+        else:
+            surf = pygame.transform.scale_by(object_type.image, SCALE_FACTOR)
+            Sprite(pos, surf, z=layer).add(self.all_sprites)
 
     def _setup_player_warp(self, pos: tuple[int, int], obj: TiledObject):
         """
@@ -608,19 +600,6 @@ class GameMap:
                             pos, obj, Layer.MAIN, self.collision_sprites
                         ),
                     )
-                elif tilemap_layer.name == "Trees":
-                    _setup_object_layer(
-                        tilemap_layer,
-                        lambda pos, obj: self._setup_tree_object(
-                            pos,
-                            obj,
-                            (
-                                self.all_sprites,
-                                self.collision_sprites,
-                                self.tree_sprites,
-                            ),
-                        ),
-                    )
                 elif tilemap_layer.name == "Player":
                     _setup_object_layer(
                         tilemap_layer,
@@ -655,14 +634,10 @@ class GameMap:
                     # decorative objects will be created as collideable object
                     _setup_object_layer(
                         tilemap_layer,
-                        lambda pos, obj: self._setup_collideable_object(
+                        lambda pos, obj, obj_layer=layer: self._setup_map_object(
                             pos,
                             obj,
-                            layer,  # noqa: B023 # TODO: Fix B023 to avoid potential UnboundLocalError
-                            (
-                                self.all_sprites,
-                                self.collision_sprites,
-                            ),
+                            obj_layer,
                         ),
                     )
 

--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -365,31 +365,32 @@ class Level:
     def draw_hitboxes(self):
         if self.show_hitbox_active:
             offset = pygame.Vector2(0, 0)
-            offset.x = -(self.player.rect.centerx - SCREEN_WIDTH / 2)
-            offset.y = -(self.player.rect.centery - SCREEN_HEIGHT / 2)
+            offset.x = -(self.get_camera_center()[0] - SCREEN_WIDTH / 2)
+            offset.y = -(self.get_camera_center()[1] - SCREEN_HEIGHT / 2)
 
-            for y in range(len(AIData.Matrix)):
-                for x in range(len(AIData.Matrix[y])):
-                    if not AIData.Matrix[y][x]:
-                        surf = pygame.Surface(
-                            (SCALED_TILE_SIZE, SCALED_TILE_SIZE), pygame.SRCALPHA
-                        )
-                        surf.fill((255, 128, 128))
-                        pygame.draw.rect(
-                            surf,
-                            (0, 0, 0),
-                            (0, 0, SCALED_TILE_SIZE, SCALED_TILE_SIZE),
-                            2,
-                        )
-                        surf.set_alpha(92)
+            if AIData.setup:
+                for y in range(len(AIData.Matrix)):
+                    for x in range(len(AIData.Matrix[y])):
+                        if not AIData.Matrix[y][x]:
+                            surf = pygame.Surface(
+                                (SCALED_TILE_SIZE, SCALED_TILE_SIZE), pygame.SRCALPHA
+                            )
+                            surf.fill((255, 128, 128))
+                            pygame.draw.rect(
+                                surf,
+                                (0, 0, 0),
+                                (0, 0, SCALED_TILE_SIZE, SCALED_TILE_SIZE),
+                                2,
+                            )
+                            surf.set_alpha(92)
 
-                        self.display_surface.blit(
-                            surf,
-                            (
-                                x * SCALED_TILE_SIZE + offset.x,
-                                y * SCALED_TILE_SIZE + offset.y,
-                            ),
-                        )
+                            self.display_surface.blit(
+                                surf,
+                                (
+                                    x * SCALED_TILE_SIZE + offset.x,
+                                    y * SCALED_TILE_SIZE + offset.y,
+                                ),
+                            )
 
             for sprite in self.collision_sprites:
                 rect = sprite.rect.copy()


### PR DESCRIPTION
## Summary

This PR fixes several issues with loading the game map.

**Correct loading of all Trees**
- now all Trees are loaded, and they are loaded regardless of their layer by using their "type" property

**Fixed a bug where the game crashes when a decorative map object has no hitbox**
- map objects without hitbox / tile collider do no longer throw an error but render as non-collideable sprites instead

**Fixed a bug where the game crashes when hitboxes should be shown and AIData is not setup**
- hitbox overlay is now centered around the Level's camera instead of the Player

## Checklist

- [X] I have tested this change locally and it works as expected.
- [X] I have made sure that the code follows the formatting and style guidelines of the project.

## Labels
https://github.com/sloukit/pydew-valley-uzh/labels/type%3A%20bugfix
