### PR TITLE
Fix the comparison fail for farming NPC behaviour

### DIFF
--- a/src/screens/game_map.py
+++ b/src/screens/game_map.py
@@ -595,7 +595,7 @@ class GameMap:
             tree_sprites=self.tree_sprites,
         )
         behaviour = obj.properties.get("behaviour")
-        if behaviour != "Woodcutting" and gmap != Map.NEW_FARM:
+        if behaviour != "Woodcutting" and gmap == Map.NEW_FARM:
             npc.conditional_behaviour_tree = NPCBehaviourTree.Farming
         else:
             npc.conditional_behaviour_tree = NPCBehaviourTree.Woodcutting


### PR DESCRIPTION
## Summary

This PR fixes a bug described by @13-Sonja on Discord related to NPC behaviour (namely, none of them attempting to farm on the farm map only).

## Checklist

- [X] I have tested this change locally and it works as expected.
- [X] I have made sure that the code follows the formatting and style guidelines of the project.
