### PR TITLE
Remove jsmin dependency

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[report]
+show_missing = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ deps = -r{toxinidir}/requirements.txt
 deps =
     {[testenv]deps}
     pytest
-commands = pytest src --doctest-modules
+commands = pytest src --doctest-modules --cov=src
 
 [testenv:format]
 deps = ruff

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,3 @@
 pytest==8.3
 tox==4.16
+pytest-cov==5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 PyTMX==3.32
-jsmin==3.0.1
 pathfinding==1.0.10
 pygame-ce==2.5.0

--- a/src/gui/interface/dialog.py
+++ b/src/gui/interface/dialog.py
@@ -1,15 +1,14 @@
-import json
 import textwrap
 from operator import attrgetter
 
 import pygame
-from jsmin import jsmin  # JSON minifier function (removes comments, notably)
 
 from src.enums import Layer
 from src.settings import CHARS_PER_LINE, SCREEN_HEIGHT, SCREEN_WIDTH, TB_SIZE
 from src.sprites.base import Sprite
 from src.support import resource_path
 from src.timer import Timer
+from src import utils
 
 
 class TextBox(Sprite):
@@ -148,8 +147,8 @@ class DialogueManager:
         # Open the dialogues file and dump all of its content in here,
         # while purging the raw file content from its comments.
         with open(resource_path("data/dialogues.json"), "r") as dialogue_file:
-            self.dialogues: dict[str, list[list[str, str]]] = json.loads(
-                jsmin(dialogue_file.read())
+            self.dialogues: dict[str, list[list[str, str]]] = utils.json_loads(
+                dialogue_file.read()
             )
         self._tb_list: list[TextBox] = []
         self._msg_index: int = 0

--- a/src/savefile/savefile.py
+++ b/src/savefile/savefile.py
@@ -2,12 +2,12 @@ import json
 from itertools import chain
 
 import pygame
-from jsmin import jsmin
 
 from src.enums import FarmingTool, InventoryResource, SeedType, StudyGroup
 from src.savefile.tile_info import PlantInfo, TileInfo
 from src.settings import Coordinate, GogglesStatus
 from src.support import resource_path
+from src import utils
 
 _NONSEED_INVENTORY_DEFAULT_AMOUNT = 20
 _SEED_INVENTORY_DEFAULT_AMOUNT = 5
@@ -82,7 +82,7 @@ def _decoder_object_hook(o):
 
 def _load_internal():
     with open(resource_path("data/save.json"), "r") as file:
-        return json.loads(jsmin(file.read()), object_hook=_decoder_object_hook)
+        return utils.json_loads(file.read(), object_hook=_decoder_object_hook)
 
 
 class SaveFile:

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -1,0 +1,47 @@
+import unittest
+
+import src.utils as utils
+
+
+class TestJSONWithCommentsDecoder(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_normal_json(self):
+        text = """
+        {
+            "test":[
+                ["foo", "bar"],
+                ["baz", "qux"]
+            ]
+        }
+        """
+        expected = {"test": [["foo", "bar"], ["baz", "qux"]]}
+        actual = utils.json_loads(text)
+        self.assertEqual(expected, actual)
+
+    def test_json_with_lines_commented_out(self):
+        text = """
+        {
+            "test":[
+                // ["foo", "bar"],
+                ["baz", "qux"]
+            ]
+        }
+        """
+        expected = {"test": [["baz", "qux"]]}
+        actual = utils.json_loads(text)
+        self.assertEqual(expected, actual)
+
+    def test_json_with_trailing_comments(self):
+        text = """
+        {  // test
+            "test":[
+                ["foo", "bar"], // trailing comment
+                ["baz", "qux"]  // another comment
+            ]
+        }
+        """
+        expected = {"test": [["foo", "bar"], ["baz", "qux"]]}
+        actual = utils.json_loads(text)
+        self.assertEqual(expected, actual)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,35 @@
+import json
+import typing
+
+
+_DOUBLE_SLASH = "//"
+
+
+class JSONWithCommentsDecoder(json.JSONDecoder):
+    """JSON Decoder which allows comments starting with //.
+
+    Comments are not preserved. They are simply useful to document
+    input files.
+    """
+
+    def decode(self, s: str) -> typing.Any:
+        # import pdb; pdb.set_trace()
+        lines = s.split("\n")
+        # filter out any line with leading //
+        lines = (line for line in lines if not line.strip().startswith(_DOUBLE_SLASH))
+
+        # ignore any text on a line after a //
+        lines = [line.split(_DOUBLE_SLASH, maxsplit=1)[0] for line in lines]
+
+        s = "\n".join(lines)
+        return super().decode(s)
+
+
+def json_loads(s: str, **kwargs) -> typing.Any:
+    """Helper function to decode a JSON string.
+
+    JSON inputs can contain comments beginning with //.
+
+    Wrapper function for `json.loads`, with custom decoder.
+    """
+    return json.loads(s, cls=JSONWithCommentsDecoder, **kwargs)


### PR DESCRIPTION
## Summary

This PR removes `jsmin` as a dependency and replaces it with a built-in utility that implements a subset of the functionality that we need `jsmin` (i.e., parsing json files which contain c-style single line comments beginning with `//`).

This is needed in order to trim down the external dependencies we need and support running the game in pygbag in a browser. `pygbag` is limited in the external dependencies that it can resolve, so I think we need to just remove this.

## Checklist

- [x] I have tested this change locally and it works as expected.
- [x] I have made sure that the code follows the formatting and style guidelines of the project.

