### PR TITLE
Fixed #135 and #136

### DIFF
--- a/src/gui/interface/dialog.py
+++ b/src/gui/interface/dialog.py
@@ -130,7 +130,7 @@ class TextBox(Sprite):
         ]
         self.image.fblits(blit_list)
 
-    def draw(self, display_surface: pygame.Surface, rect: pygame.Rect):
+    def draw(self, display_surface: pygame.Surface, rect: pygame.Rect, camera):
         display_surface.blit(self.image, self.rect)
 
 

--- a/src/savefile/savefile.py
+++ b/src/savefile/savefile.py
@@ -60,7 +60,7 @@ def _extract_tile_info(o: dict):
             plant_info_orig = info.get("plant_info")
             if plant_info_orig is not None:
                 new_plant_info = PlantInfo(
-                    SeedType(plant_info_orig["plant_type"], plant_info_orig["age"])
+                    SeedType(plant_info_orig["plant_type"]), plant_info_orig["age"]
                 )
             else:
                 new_plant_info = None


### PR DESCRIPTION
## Summary

This PR fixes #135 and #136.

For issue #135, the draw function in the `AllSprites` sprite group assumes that the sprites it draws have the same parameters, including the `TextBox` sprite, which supposedly has 4 parameters but only has 3. Adding a `camera` parameter to the `draw` function of `TextBox` sprite seemed to bring back the text box feature's functionality.

For issue #136, SeedType only accepts one value, but it was given two. Changing how the `plant_info` values were handled seemed to fix the save file.

## Checklist

- [x] I have tested this change locally and it works as expected.
- [x] I have made sure that the code follows the formatting and style guidelines of the project.

## Labels
`type: bug`, `area: textbox`, `game-gameplay`