### PR TITLE
Fixed audio not playing on start

### DIFF
--- a/src/gui/menu/description.py
+++ b/src/gui/menu/description.py
@@ -346,6 +346,10 @@ class VolumeDescription(Description):
             or self.sfx_slider.handle_event(event)
         )
 
+    def reset_volumes(self):
+        self.sound_slider.set_value(50)
+        self.sfx_slider.set_value(50)
+
     def update_music(self, value):
         self.sounds["music"].set_volume(min((value / 1000), 0.4))
 

--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -40,7 +40,7 @@ from src.sprites.entities.character import Character
 from src.sprites.entities.player import Player
 from src.sprites.particle import ParticleSprite
 from src.sprites.setup import ENTITY_ASSETS
-from src.support import load_data, map_coords_to_tile, resource_path
+from src.support import load_data, map_coords_to_tile, resource_path, save_data
 
 _TO_PLAYER_SPEED_INCREASE_THRESHOLD = 200
 
@@ -301,10 +301,14 @@ class Level:
         volume = 0.1
         try:
             sound_data = load_data("volume.json")
-            volume = sound_data["music"]
-            # sfx = sound_data['sfx']
         except FileNotFoundError:
-            pass
+            sound_data = {
+                "music": 50,
+                "sfx": 50,
+            }
+            save_data(sound_data, "volume.json")
+        volume = sound_data["music"]
+        # sfx = sound_data['sfx']
         self.sounds["music"].set_volume(min((volume / 1000), 0.4))
         self.sounds["music"].play(-1)
 

--- a/src/screens/menu_settings.py
+++ b/src/screens/menu_settings.py
@@ -49,6 +49,7 @@ class SettingsMenu(GeneralMenu):
             self.switch_screen(GameState.PAUSE)
         if text == "Reset":
             self.keybinds_description.reset_keybinds()
+            self.volume_description.reset_volumes()
 
     # events
     def handle_event(self, event: pygame.event.Event) -> bool:


### PR DESCRIPTION
## Summary

This PR fixes the following issues (as described by sophie in discord):

- music only played after opening the volume menu.
- music and sfx volumes didnt reset after clicking `reset` on menu.

## Checklist

- [x] I have tested this change locally and it works as expected.
- [x] I have made sure that the code follows the formatting and style guidelines of the project.

## Labels
`type: bugfix`, `game-audio`
