### PR TITLE
fix berry bushes

### DIFF
--- a/src/sprites/objects/berry_bush.py
+++ b/src/sprites/objects/berry_bush.py
@@ -77,4 +77,4 @@ class BerryBush(CollideableMapObject):
     def draw(self, display_surface: pygame.Surface, rect: pygame.Rect, camera):
         super().draw(display_surface, rect, camera)
         for fruit in self.fruit_sprites:
-            fruit.draw(display_surface, rect, camera)
+            fruit.draw(display_surface, camera.apply(fruit), camera)


### PR DESCRIPTION
## Summary

This PR fixes the berry bushes. They were displaying only one berry in an incorrect position. One line in the drawing method was not updated when the camera was changed.

## Checklist

- [x] I have tested this change locally and it works as expected.
- [x] I have made sure that the code follows the formatting and style guidelines of the project.

## Labels
`type: bugfix`
