### PR TITLE
Switch to outgroup

### DIFF
--- a/data/maps/farm_new.tmx
+++ b/data/maps/farm_new.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.10.2" orientation="orthogonal" renderorder="right-down" width="80" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="24" nextobjectid="381">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" width="80" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="24" nextobjectid="381">
  <tileset firstgid="1" source="../tilesets/grass_tileset.tsx"/>
  <tileset firstgid="78" source="../tilesets/Interaction.tsx"/>
  <tileset firstgid="80" source="../tilesets/fence_tileset.tsx"/>

--- a/data/maps/farm_new.tmx
+++ b/data/maps/farm_new.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" width="80" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="24" nextobjectid="380">
+<map version="1.10" tiledversion="1.10.2" orientation="orthogonal" renderorder="right-down" width="80" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="24" nextobjectid="381">
  <tileset firstgid="1" source="../tilesets/grass_tileset.tsx"/>
  <tileset firstgid="78" source="../tilesets/Interaction.tsx"/>
  <tileset firstgid="80" source="../tilesets/fence_tileset.tsx"/>
@@ -767,6 +767,7 @@
     <property name="label" value="to_forest_down"/>
    </properties>
   </object>
+  <object id="380" name="Outgroup Farm" x="691.219" y="96.2339" width="415.471" height="358.101"/>
  </objectgroup>
  <layer id="25" name="farmable_outgroup" width="80" height="40">
   <data encoding="csv">

--- a/main.py
+++ b/main.py
@@ -94,7 +94,7 @@ class Game:
             self.player.assign_tool,
             self.player.assign_seed,
         )
-        self.outgroup_menu = OutgroupMenu(self.player,self.switch_state)
+        self.outgroup_menu = OutgroupMenu(self.player, self.switch_state)
 
         # dialog
         self.all_sprites = AllSprites()
@@ -107,7 +107,7 @@ class Game:
             GameState.SETTINGS: self.settings_menu,
             GameState.SHOP: self.shop_menu,
             GameState.INVENTORY: self.inventory_menu,
-            GameState.OUTGROUP_MENU: self.outgroup_menu
+            GameState.OUTGROUP_MENU: self.outgroup_menu,
         }
         self.current_state = GameState.MAIN_MENU
 

--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ from src.screens.menu_main import MainMenu
 from src.screens.menu_pause import PauseMenu
 from src.screens.menu_settings import SettingsMenu
 from src.screens.shop import ShopMenu
+from src.screens.switch_to_outgroup_menu import OutgroupMenu
 from src.settings import (
     EMOTE_SIZE,
     SCREEN_HEIGHT,
@@ -93,6 +94,7 @@ class Game:
             self.player.assign_tool,
             self.player.assign_seed,
         )
+        self.outgroup_menu = OutgroupMenu(self.player,self.switch_state)
 
         # dialog
         self.all_sprites = AllSprites()
@@ -105,6 +107,7 @@ class Game:
             GameState.SETTINGS: self.settings_menu,
             GameState.SHOP: self.shop_menu,
             GameState.INVENTORY: self.inventory_menu,
+            GameState.OUTGROUP_MENU: self.outgroup_menu
         }
         self.current_state = GameState.MAIN_MENU
 

--- a/src/enums.py
+++ b/src/enums.py
@@ -38,6 +38,7 @@ class GameState(IntEnum):
     # saves and then sets its current state back to PLAY
     SAVE_AND_RESUME = 9
     INVENTORY = 10
+    OUTGROUP_MENU = 11
 
 
 # NOTE : DO NOT pay attention to anything the IDE might complain about in this class, as the enum generation mechanisms

--- a/src/npc/npc.py
+++ b/src/npc/npc.py
@@ -48,6 +48,8 @@ class NPC(NPCBase):
         self.soil_area = soil_manager.get_area(self.study_group)
         self.has_necklace = False
         self.has_hat = False
+        self.has_horn = False
+        self.has_outgroup_skin = False
 
         # TODO: Ensure that the NPC always has all needed seeds it needs
         #  in its inventory
@@ -77,6 +79,8 @@ class NPC(NPCBase):
         else:
             self.has_necklace = False
             self.has_hat = False
+            self.has_horn = True
+            self.has_outgroup_skin = True
 
     def update(self, dt):
         super().update(dt)

--- a/src/savefile/savefile.py
+++ b/src/savefile/savefile.py
@@ -6,7 +6,14 @@ import pygame
 from src import utils
 from src.enums import FarmingTool, InventoryResource, SeedType, StudyGroup
 from src.savefile.tile_info import PlantInfo, TileInfo
-from src.settings import Coordinate, GogglesStatus, HatStatus, NecklaceStatus
+from src.settings import (
+    Coordinate,
+    GogglesStatus,
+    HatStatus,
+    HornStatus,
+    NecklaceStatus,
+    OutgroupSkinStatus,
+)
 from src.support import resource_path
 
 _NONSEED_INVENTORY_DEFAULT_AMOUNT = 20
@@ -90,6 +97,8 @@ class SaveFile:
     _has_hat: HatStatus
     _has_necklace: NecklaceStatus
     _study_group: StudyGroup
+    _has_horn: HornStatus
+    _has_OutgroupSkin: OutgroupSkinStatus
     _current_tool: FarmingTool
     _current_seed: FarmingTool
     _money: int
@@ -105,6 +114,8 @@ class SaveFile:
         goggles_status: GogglesStatus,
         necklace_status: NecklaceStatus,
         hat_status: HatStatus,
+        horn_status: HornStatus,
+        outgroup_skin_status: OutgroupSkinStatus,
         money: int = 200,
         soil_data: dict[Coordinate, TileInfo] | None = None,
     ):
@@ -124,6 +135,8 @@ class SaveFile:
         self.has_goggles = goggles_status
         self.has_necklace = necklace_status
         self.has_hat = hat_status
+        self.has_horn = horn_status
+        self.has_outgroup_skin = outgroup_skin_status
         self._soil_data = soil_data or {}
 
     @classmethod
@@ -133,6 +146,8 @@ class SaveFile:
         data.setdefault("goggles_status", None)
         data.setdefault("necklace_status", None)
         data.setdefault("hat_status", True)
+        data.setdefault("horn_status", False)
+        data.setdefault("outgroup_skin_status", False)
         data.setdefault("current_tool", FarmingTool.get_first_tool_id())
         data.setdefault("current_seed", FarmingTool.get_first_seed_id())
         return SaveFile(**data)
@@ -156,6 +171,8 @@ class SaveFile:
                 "goggles_status": self.has_goggles,
                 "necklace_status": self.has_necklace,
                 "hat_status": self.has_hat,
+                "horn_status": self.has_horn,
+                "outgroup_skin_status": self.has_outgroup_skin,
                 "inventory": serialised_inventory,
             }
             if self._soil_data:

--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -189,6 +189,9 @@ class Level:
         self.outgroup_farm_entered = False
         self.outgroup_farm_time_entered = None
         self.outgroup_message_received = False
+        self.start_become_outgroup = False
+        self.start_become_outgroup_time = None
+        self.finish_become_outgroup = False
 
         # map
         self.load_map(GAME_MAP)
@@ -401,25 +404,31 @@ class Level:
         label_key = sign.custom_properties.get("label", "label_not_available")
         post_event(DIALOG_SHOW, dial=label_key)
 
-    def check_outgroup_farm_entered(self):
+    def check_outgroup_logic(self):
         collided_with_outgroup_farm = pygame.sprite.spritecollide(
             self.player,
             [i for i in self.interaction_sprites if i.name == "Outgroup Farm"],
             False,
         )
+
+        # Starts timer for 60 seconds when player is in outgroup farm
         if collided_with_outgroup_farm:
             if not self.outgroup_farm_entered:
                 self.outgroup_farm_time_entered = pygame.time.get_ticks()
                 self.outgroup_farm_entered = True
+
+        # Resets the timer when player exits the farm
         else:
             self.outgroup_farm_entered = False
             self.outgroup_farm_time_entered = None
             self.outgroup_message_received = False
 
+        # If the player is in the farm and 60 seconds (currently 30s) have passed
         if (
             self.outgroup_farm_entered
-            and pygame.time.get_ticks() - self.outgroup_farm_time_entered >= 6000
+            and pygame.time.get_ticks() - self.outgroup_farm_time_entered >= 30000
         ):
+            # Checks if player has already received the message and is not part of the outgroup
             if (
                 not self.outgroup_message_received
                 and self.player.study_group != StudyGroup.OUTGROUP
@@ -427,8 +436,22 @@ class Level:
                 self.outgroup_message_received = True
                 self.switch_screen(GameState.OUTGROUP_MENU)
 
+        # Resets so that message can be displayed again if player exits and reenters farm
         if not self.outgroup_farm_entered:
             self.outgroup_message_receieved = False
+
+        # checks 60 seconds and 120 seconds after player joins outgroup to convert appearance
+        if self.player.study_group == StudyGroup.OUTGROUP:
+            if not self.start_become_outgroup:
+                self.start_become_outgroup_time = pygame.time.get_ticks()
+                self.start_become_outgroup = True
+            elif self.finish_become_outgroup:
+                pass
+            elif pygame.time.get_ticks() - self.start_become_outgroup_time > 120000:
+                self.player.has_outgroup_skin = True
+                self.finish_become_outgroup = True
+            elif pygame.time.get_ticks() - self.start_become_outgroup_time > 60000:
+                self.player.has_horn = True
 
     def handle_event(self, event: pygame.event.Event) -> bool:
         hitbox_key = self.player.controls.DEBUG_SHOW_HITBOXES.control_value
@@ -650,7 +673,7 @@ class Level:
         # update
         self.game_time.update()
         self.check_map_exit()
-        self.check_outgroup_farm_entered()
+        self.check_outgroup_logic()
 
         if self.current_minigame and self.current_minigame.running:
             self.current_minigame.update(dt)

--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -185,12 +185,10 @@ class Level:
         # minigame
         self.current_minigame = None
 
-        #switch to outgroup farm
+        # switch to outgroup farm
         self.outgroup_farm_entered = False
         self.outgroup_farm_time_entered = None
         self.outgroup_message_received = False
-
-
 
         # map
         self.load_map(GAME_MAP)
@@ -405,7 +403,9 @@ class Level:
 
     def check_outgroup_farm_entered(self):
         collided_with_outgroup_farm = pygame.sprite.spritecollide(
-            self.player, [i for i in self.interaction_sprites if i.name == "Outgroup Farm"], False
+            self.player,
+            [i for i in self.interaction_sprites if i.name == "Outgroup Farm"],
+            False,
         )
         if collided_with_outgroup_farm:
             if not self.outgroup_farm_entered:
@@ -416,15 +416,19 @@ class Level:
             self.outgroup_farm_time_entered = None
             self.outgroup_message_received = False
 
-        if self.outgroup_farm_entered and pygame.time.get_ticks() - self.outgroup_farm_time_entered >= 6000:
-            if not self.outgroup_message_received and self.player.study_group != StudyGroup.OUTGROUP:
+        if (
+            self.outgroup_farm_entered
+            and pygame.time.get_ticks() - self.outgroup_farm_time_entered >= 6000
+        ):
+            if (
+                not self.outgroup_message_received
+                and self.player.study_group != StudyGroup.OUTGROUP
+            ):
                 self.outgroup_message_received = True
                 self.switch_screen(GameState.OUTGROUP_MENU)
 
         if not self.outgroup_farm_entered:
             self.outgroup_message_receieved = False
-
-
 
     def handle_event(self, event: pygame.event.Event) -> bool:
         hitbox_key = self.player.controls.DEBUG_SHOW_HITBOXES.control_value

--- a/src/screens/switch_to_outgroup_menu.py
+++ b/src/screens/switch_to_outgroup_menu.py
@@ -1,0 +1,28 @@
+from collections.abc import Callable
+import pygame
+
+from src.enums import GameState, StudyGroup
+from src.gui.menu.general_menu import GeneralMenu
+
+# This menu is for when the player decides whether they will join the outgroup.
+
+class OutgroupMenu(GeneralMenu):
+    def __init__(self,player,switch_screen: Callable[[str],None]):
+        options = ["Yes (Warning: You cannot go back after switching.)","No"]
+        title = "Would you like to join the outgroup?"
+        size = (400,400)
+        self.player = player
+        super().__init__(title,options,switch_screen,size)
+
+    def button_action(self,text):
+        if "Yes" in text:
+            self.player.study_group = StudyGroup.OUTGROUP
+            self.player.has_hat = False
+            self.player.has_necklace = False
+            self.switch_screen(GameState.PLAY)
+        elif "No" in text:
+            self.switch_screen(GameState.PLAY)
+    def outgroup_handle_event(self, event: pygame.event.Event) -> bool:
+        if super().handle_event(event):
+            return True
+        return False

--- a/src/screens/switch_to_outgroup_menu.py
+++ b/src/screens/switch_to_outgroup_menu.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+
 import pygame
 
 from src.enums import GameState, StudyGroup
@@ -6,15 +7,16 @@ from src.gui.menu.general_menu import GeneralMenu
 
 # This menu is for when the player decides whether they will join the outgroup.
 
-class OutgroupMenu(GeneralMenu):
-    def __init__(self,player,switch_screen: Callable[[str],None]):
-        options = ["Yes (Warning: You cannot go back after switching.)","No"]
-        title = "Would you like to join the outgroup?"
-        size = (400,400)
-        self.player = player
-        super().__init__(title,options,switch_screen,size)
 
-    def button_action(self,text):
+class OutgroupMenu(GeneralMenu):
+    def __init__(self, player, switch_screen: Callable[[str], None]):
+        options = ["Yes (Warning: You cannot go back after switching.)", "No"]
+        title = "Would you like to join the outgroup?"
+        size = (400, 400)
+        self.player = player
+        super().__init__(title, options, switch_screen, size)
+
+    def button_action(self, text):
         if "Yes" in text:
             self.player.study_group = StudyGroup.OUTGROUP
             self.player.has_hat = False
@@ -22,6 +24,7 @@ class OutgroupMenu(GeneralMenu):
             self.switch_screen(GameState.PLAY)
         elif "No" in text:
             self.switch_screen(GameState.PLAY)
+
     def outgroup_handle_event(self, event: pygame.event.Event) -> bool:
         if super().handle_event(event):
             return True

--- a/src/screens/switch_to_outgroup_menu.py
+++ b/src/screens/switch_to_outgroup_menu.py
@@ -4,14 +4,15 @@ import pygame
 
 from src.enums import GameState, StudyGroup
 from src.gui.menu.general_menu import GeneralMenu
+from src.settings import SCREEN_HEIGHT, SCREEN_WIDTH
 
 # This menu is for when the player decides whether they will join the outgroup.
 
 
 class OutgroupMenu(GeneralMenu):
     def __init__(self, player, switch_screen: Callable[[str], None]):
-        options = ["Yes (Warning: You cannot go back after switching.)", "No"]
-        title = "Would you like to join the outgroup?"
+        options = ["Yes", "No"]
+        title = "Would you like to join the outgroup?\n(Warning: You cannot go back after switching.)"
         size = (400, 400)
         self.player = player
         super().__init__(title, options, switch_screen, size)
@@ -29,3 +30,14 @@ class OutgroupMenu(GeneralMenu):
         if super().handle_event(event):
             return True
         return False
+
+    def draw_title(self):
+        text_surf = self.font.render(self.title, False, "Black")
+        midtop = (SCREEN_WIDTH / 2, SCREEN_HEIGHT / 20)
+        text_rect = text_surf.get_frect(midtop=midtop)
+
+        bg_rect = pygame.Rect((0, 0), (600, 100))
+        bg_rect.center = text_rect.center
+
+        pygame.draw.rect(self.display_surface, "White", bg_rect, 0, 4)
+        self.display_surface.blit(text_surf, text_rect)

--- a/src/settings.py
+++ b/src/settings.py
@@ -12,6 +12,8 @@ type AniFrames = dict[str, list[pygame.Surface]]
 type GogglesStatus = bool | None
 type NecklaceStatus = bool | None
 type HatStatus = bool | None
+type HornStatus = bool | None
+type OutgroupSkinStatus = bool | None
 
 SCREEN_WIDTH, SCREEN_HEIGHT = 1280, 720
 TILE_SIZE = 16

--- a/src/sprites/entities/character.py
+++ b/src/sprites/entities/character.py
@@ -153,16 +153,17 @@ class Character(Entity, ABC):
                 blit_list.append((hat_frame, rect))
 
         elif self.study_group == StudyGroup.OUTGROUP:
-            horn_state = EntityState(f"horn_{self.state.value}")
-            horn_ani = self.assets[horn_state][self.facing_direction]
-            horn_frame = horn_ani.get_frame(self.frame_index)
+            if self.has_outgroup_skin:
+                skin_state = EntityState(f"outgroup_{self.state.value}")
+                skin_ani = self.assets[skin_state][self.facing_direction]
+                skin_frame = skin_ani.get_frame(self.frame_index)
+                blit_list.append((skin_frame, rect))
 
-            skin_state = EntityState(f"outgroup_{self.state.value}")
-            skin_ani = self.assets[skin_state][self.facing_direction]
-            skin_frame = skin_ani.get_frame(self.frame_index)
-
-            blit_list.append((skin_frame, rect))
-            blit_list.append((horn_frame, rect))
+            if self.has_horn:
+                horn_state = EntityState(f"horn_{self.state.value}")
+                horn_ani = self.assets[horn_state][self.facing_direction]
+                horn_frame = horn_ani.get_frame(self.frame_index)
+                blit_list.append((horn_frame, rect))
 
         display_surface.fblits(blit_list)
 

--- a/src/sprites/entities/player.py
+++ b/src/sprites/entities/player.py
@@ -272,8 +272,6 @@ class Player(Character):
         if (round(time.time() - self.bath_time)) == BATH_STATUS_TIMEOUT:
             self.bathstat = False
 
-
-
     def teleport(self, pos: tuple[float, float]):
         """
         Moves the Player rect directly to the specified point without checking

--- a/src/sprites/entities/player.py
+++ b/src/sprites/entities/player.py
@@ -74,6 +74,8 @@ class Player(Character):
         self.has_goggles = save_file.has_goggles
         self.has_necklace = save_file.has_necklace
         self.has_hat = save_file.has_hat
+        self.has_horn = save_file.has_horn
+        self.has_outgroup_skin = save_file.has_outgroup_skin
         self.study_group: StudyGroup = save_file.study_group
 
         self.emote_manager = emote_manager

--- a/src/sprites/entities/player.py
+++ b/src/sprites/entities/player.py
@@ -272,6 +272,8 @@ class Player(Character):
         if (round(time.time() - self.bath_time)) == BATH_STATUS_TIMEOUT:
             self.bathstat = False
 
+
+
     def teleport(self, pos: tuple[float, float]):
         """
         Moves the Player rect directly to the specified point without checking


### PR DESCRIPTION
## Summary

This PR implements players being able to switch to the outgroup (as described in the project tasklist).

Players are able to switch to the outgroup after standing in the outgroup farm for 6 seconds (it should be 60 but it was shortened for convenience). I created a new rectangle object in the Interactions layer in Tiled to do this (which is why there is 1 more object in the farm_new.tmx file). 
EDIT: fixed the textboxes in the switch to outgroup menu, made the change to the outgroup more gradual (60 seconds for horn, 120 seconds for the skin change). Also changed the time to trigger the menu from 6 to 30 seconds.

![CleanShot 2024-09-26 at 15 59 54@2x](https://github.com/user-attachments/assets/112db7b8-3533-4dea-9b30-a688824e2ca3)
![CleanShot 2024-09-26 at 16 00 10@2x](https://github.com/user-attachments/assets/c5e29b0b-474c-46c6-9539-f9f19445d20d)
![CleanShot 2024-09-26 at 16 01 10@2x](https://github.com/user-attachments/assets/6cf9fdf4-4b7d-4448-a1d3-65d9b65f3201)
![CleanShot 2024-09-26 at 16 02 13@2x](https://github.com/user-attachments/assets/2fdf37d3-7621-4663-9601-183e4181d726)



## Checklist

- [ x] I have tested this change locally and it works as expected.
- [ x] I have made sure that the code follows the formatting and style guidelines of the project.

## Labels
`type: feature`, `area: players who switch are labeled StudyGroup.OUTGROUP`, `game- players see a menu asking whether or not they wish to switch to the outgroup, and if they do their character body is changed to resemble the outgroup NPCs`,
