### PR TITLE
Fix Bug : Player camera zooming in cinamatic zoom areas near lake

### DIFF
--- a/src/camera/zoom_manager.py
+++ b/src/camera/zoom_manager.py
@@ -73,7 +73,7 @@ class ZoomManager:
             entered_zoom_area = target.rect.collideobjects(
                 self._zoom_areas, key=lambda obj: obj.area
             )
-            if entered_zoom_area is not None:
+            if entered_zoom_area is not None and target.zoom_allowed:
                 self._prepare_zoom_in(entered_zoom_area)
             return
 

--- a/src/gui/scene_animation.py
+++ b/src/gui/scene_animation.py
@@ -89,3 +89,6 @@ class SceneAnimation:
 
     def update(self, dt):
         self.animate(dt)
+
+        # check the if the zoom is allowed
+        self.zoom_allowed = self.active

--- a/src/sprites/entities/player.py
+++ b/src/sprites/entities/player.py
@@ -94,6 +94,9 @@ class Player(Character):
         self.created_time = time.time()
         self.delay_time_speed = 0.25
 
+        # check if the zoom is allowed
+        self.zoom_allowed = False
+
     def focus_entity(self, entity: Entity):
         if self.focused_entity:
             self.focused_entity.unfocus()


### PR DESCRIPTION
This pull request is **hopefully** a fix to a bug presented in the issues section #142 by @DangerousVanilla.
-- Approach
Added a condition to the zoom manager "update" method to let only the scene animation object to zoom (Hope that is true). To achieve this, I provided a "zoom_allowed" attribute to both the Player and the SceneAnimation class.

-- Test with formatlint.py
I tested the game with formatlint.py and it worked !