### PR TITLE
fixed bug ('Player' object has no attribute 'abort_path')

### DIFF
--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -534,30 +534,37 @@ class Level:
                 if npc.study_group == StudyGroup.INGROUP
             ]
             if sequence_type == ScriptedSequenceType.NPC_RECEIVES_NECKLACE:
-                npc = random.choice(npcs)
-                npcs.remove(npc)
+                npc_in_center = random.choice(npcs)
+                npcs.remove(npc_in_center)
                 npcs.append(self.player)
             else:
-                npc = self.player
+                npc_in_center = self.player
             self.cutscene_animation.set_current_animation("ingroup_gathering")
             self.cutscene_animation.is_end_condition_met = partial(
-                self.end_scripted_sequence, sequence_type, npc
+                self.end_scripted_sequence, sequence_type, npc_in_center
             )
             self.prev_player_pos = self.player.rect.center
             meeting_pos = self.cutscene_animation.targets[0].pos
-            # move player other npc to the meeting point and make him face to the east (right)
-            npc.teleport(meeting_pos)
-            npc.direction = pygame.Vector2(1, 0)
+            # move player other npc_in_center to the meeting point and make him face to the east (right)
+            npc_in_center.teleport(meeting_pos)
+            # npc_in_center.direction = pygame.Vector2(1, 0)
+            npc_in_center.direction.update((1, 0))
+            npc_in_center.get_facing_direction()
+            npc_in_center.direction.update((0, 0))
+
             # spread all ingroup npc in half-circle of 2 * SCALED_TILE_SIZE diameter
             # from north to south clockwise
             # and make them face the player in the center
             distance = pygame.Vector2(0, -2 * SCALED_TILE_SIZE)
             rot_by = (180) / (len(npcs) - 1)
             angle = 0
+
             for npc in npcs:
                 new_pos = meeting_pos + distance.rotate(angle)
-                npc.abort_path()
-                npc.direction = -distance.rotate(angle)
+                npc.direction.update(-distance.rotate(angle))
+                npc.get_facing_direction()
+                npc.direction.update((0, 0))
+
                 npc.teleport(new_pos)
                 angle += rot_by
             self.cutscene_animation.reset()


### PR DESCRIPTION
## Summary

This PR fixes bug ('Player' object has no attribute 'abort_path') from PR #198 

I'm using now a different way of stoping and facing all NPCs in the right direction.

## Checklist
- [x] I have checked that my revert leaves the codebase in the same state as before the target PR.


## Labels
`type: fix`
