### PR TITLE
added panel with current FPS rate

### DIFF
--- a/main.py
+++ b/main.py
@@ -84,7 +84,12 @@ class Game:
 
         # screens
         self.level = Level(
-            self.switch_state, self.tmx_maps, self.frames, self.sounds, self.save_file
+            self.switch_state,
+            self.tmx_maps,
+            self.frames,
+            self.sounds,
+            self.save_file,
+            self.clock,
         )
         self.player = self.level.player
 

--- a/src/overlay/fps.py
+++ b/src/overlay/fps.py
@@ -1,0 +1,45 @@
+import pygame
+
+from src.settings import OVERLAY_POSITIONS
+from src.support import import_font
+
+
+class FPS:
+    def __init__(self, clock: pygame.time.Clock):
+        # setup
+        self.display_surface = pygame.display.get_surface()
+        self.clock = clock
+
+        # dimensions
+        self.left = 20
+        self.top = 20
+
+        width, height = 180, 50
+        self.font = import_font(40, "font/LycheeSoda.ttf")
+
+        self.rect = pygame.Rect(self.left, self.top, width, height)
+
+        self.rect.bottomright = OVERLAY_POSITIONS["FPS"]
+
+    def display(self):
+        # get FPS
+        fps = self.clock.get_fps()
+
+        # rects and surfs
+        pad_y = 2
+
+        label_surf = self.font.render("FPS:", False, "Black")
+        label_rect = label_surf.get_frect(
+            midleft=(self.rect.left + 20, self.rect.centery + pad_y)
+        )
+
+        fps_surf = self.font.render(f"{fps:5.1f}", False, "Black")
+        fps_rect = fps_surf.get_frect(
+            midright=(self.rect.right - 20, self.rect.centery + pad_y)
+        )
+
+        # display
+        pygame.draw.rect(self.display_surface, "White", self.rect, 0, 4)
+        pygame.draw.rect(self.display_surface, "Black", self.rect, 4, 4)
+        self.display_surface.blit(label_surf, label_rect)
+        self.display_surface.blit(fps_surf, fps_rect)

--- a/src/overlay/overlay.py
+++ b/src/overlay/overlay.py
@@ -3,12 +3,15 @@ import pygame
 from src.enums import ClockVersion
 from src.gui.health_bar import HealthProgressBar
 from src.overlay.clock import Clock
+from src.overlay.fps import FPS
 from src.overlay.game_time import GameTime
 from src.settings import OVERLAY_POSITIONS
 
 
 class Overlay:
-    def __init__(self, entity, overlay_frames, game_time: GameTime):
+    def __init__(
+        self, entity, overlay_frames, game_time: GameTime, clock: pygame.time.Clock
+    ):
         # general setup
         self.display_surface = pygame.display.get_surface()
         self.player = entity
@@ -22,6 +25,7 @@ class Overlay:
         self.health_bar = HealthProgressBar(100)
 
         self.clock = Clock(game_time, ClockVersion.DIGITAL)
+        self.FPS = FPS(clock)
 
     def display(self):
         if not self.visible:
@@ -38,6 +42,7 @@ class Overlay:
         self.display_surface.blit(tool_surf, tool_rect)
 
         self.clock.display()
+        self.FPS.display()
 
         # health bar
         self.health_bar.draw(self.display_surface)

--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -105,6 +105,7 @@ class Level:
         frames: dict[str, dict],
         sounds: SoundDict,
         save_file: SaveFile,
+        clock: pygame.time.Clock,
     ):
         # main setup
         self.display_surface = pygame.display.get_surface()
@@ -183,7 +184,7 @@ class Level:
         self.current_day = 0
 
         # overlays
-        self.overlay = Overlay(self.player, frames["overlay"], self.game_time)
+        self.overlay = Overlay(self.player, frames["overlay"], self.game_time, clock)
         self.show_hitbox_active = False
         self.show_pf_overlay = False
         self.setup_pf_overlay()

--- a/src/settings.py
+++ b/src/settings.py
@@ -38,6 +38,7 @@ OVERLAY_POSITIONS = {
     "tool": (86, 150),
     "seed": (47, 142),
     "clock": (SCREEN_WIDTH - 10, 10),
+    "FPS": (SCREEN_WIDTH - 10, SCREEN_HEIGHT - 10),
 }
 
 APPLE_POS = {


### PR DESCRIPTION
## Summary

This PR adds an overlay panel in the lower right corner showing the current FPS rate. Only in menus, the value is frozen. 

![image](https://github.com/user-attachments/assets/4acc32c1-37a2-4fed-94d7-9187dab43b89)

## Checklist

- [x] I have tested this change locally and it works as expected.
- [x] I have made sure that the code follows the formatting and style guidelines of the project.

## Labels
`type: enhancement`, `area: overlay`