### PR TITLE
fix inventory keybinds not changing

### DIFF
--- a/src/screens/inventory.py
+++ b/src/screens/inventory.py
@@ -6,6 +6,7 @@ from src.settings import SCREEN_WIDTH, SCREEN_HEIGHT
 from itertools import chain
 from operator import itemgetter
 from typing import Callable, Any
+from src.controls import Controls
 
 
 class _IMButton(ImageButton):
@@ -288,7 +289,7 @@ class InventoryMenu(AbstractMenu):
 
     def handle_event(self, event):
         if event.type == pygame.KEYDOWN:
-            if event.key == pygame.K_i:
+            if event.key == Controls.INVENTORY.control_value:
                 pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_ARROW)
                 self.switch_screen(GameState.PLAY)
         if event.type == pygame.KEYDOWN:


### PR DESCRIPTION
## Summary

This PR fixes the inventory closing not being responsive to keybind changes as described in issue #167 .
Closing the inventory was hardcoded and therefore didn't change when the keybinding for opening the inventory was changed.

## Checklist

- [x] I have tested this change locally and it works as expected.
- [x] I have made sure that the code follows the formatting and style guidelines of the project.

## Labels
`type: bugfix`
