### PR TITLE
refactor(controls): move controls to Level + make it dependent on global event loop

### DIFF
--- a/src/controls.py
+++ b/src/controls.py
@@ -94,18 +94,33 @@ class Controls(Control, Enum):
     PLANT = (pygame.BUTTON_RIGHT, "Plant Seed")
     INTERACT = (pygame.K_SPACE, "Interact")
     INVENTORY = (pygame.K_i, "Open Inventory")
+    EMOTE_WHEEL = (pygame.K_e, "Toggle Emote Wheel")
+    ADVANCE_DIALOG = (pygame.K_SPACE, "Advance Dialog")
+
     DEBUG_QUAKE = (pygame.K_m, "Start Earthquake Effect")
+    DEDUG_PLAYER_TASK = (pygame.K_b, "Show Player Task")
+    DEBUG_END_ROUND = (pygame.K_r, "Skip to End of Round")
     DEBUG_PLAYER_RECEIVES_HAT = (pygame.K_j, "Player receives hat")
     DEBUG_PLAYER_RECEIVES_NECKLACE = (pygame.K_k, "Player receives necklace")
     DEBUG_NPC_RECEIVES_NECKLACE = (pygame.K_l, "NPC receives necklace")
     DEBUG_DECIDE_TOMATO_OR_CORN = (pygame.K_u, "Decide: tomato or corn")
-    EMOTE_WHEEL = (pygame.K_e, "Toggle Emote Wheel")
     DEBUG_SHOW_HITBOXES = (pygame.K_h, "Show Hitboxes")
-    SHOW_PF_OVERLAY = (pygame.K_p, "Show Pathfinding")
-    SHOW_DIALOG = (pygame.K_t, "Show Dialog")
-    ADVANCE_DIALOG = (pygame.K_SPACE, "Advance Dialog")
-    DEDUG_PLAYER_TASK = (pygame.K_b, "Show Player Task")
-    END_ROUND = (pygame.K_r, "Skip to End of Round")
+    DEBUG_SHOW_PF_OVERLAY = (pygame.K_p, "Show Pathfinding")
+    DEBUG_SHOW_DIALOG = (pygame.K_t, "Show Dialog")
+
+    @classmethod
+    def get_control_by_value(cls, control_value: int) -> Control | None:
+        for i in cls:
+            control = cls[i.name]
+            if control.control_value == control_value:
+                return control
+
+    @classmethod
+    def update_control_state(cls, control_value: int, control_held: bool):
+        control = cls.get_control_by_value(control_value)
+        if control and not control.disabled:
+            control.click = control_held
+            control.hold = control_held
 
     @classmethod
     def as_dict(cls) -> dict[str, dict[str, str | int]]:

--- a/src/screens/inventory.py
+++ b/src/screens/inventory.py
@@ -288,6 +288,7 @@ class InventoryMenu(AbstractMenu):
             if event.key == Controls.INVENTORY.control_value:
                 pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_ARROW)
                 self.switch_screen(GameState.PLAY)
+                return True
         if event.type == pygame.KEYDOWN:
             if event.key == pygame.K_ESCAPE:
                 pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_ARROW)

--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -12,6 +12,7 @@ from src.camera import Camera
 from src.camera.camera_target import CameraTarget
 from src.camera.quaker import Quaker
 from src.camera.zoom_manager import ZoomManager
+from src.controls import Controls
 from src.enums import FarmingTool, GameState, Map, ScriptedSequenceType, StudyGroup
 from src.events import DIALOG_ADVANCE, DIALOG_SHOW, START_QUAKE, post_event
 from src.exceptions import GameMapWarning
@@ -159,11 +160,14 @@ class Level:
         self.backup_emote_mgr = self.player_emote_manager
         self.npc_emote_manager = NPCEmoteManager(self._emotes, self.all_sprites)
 
+        self.controls = Controls
+
         self.player = Player(
             pos=(0, 0),
             assets=copy.deepcopy(ENTITY_ASSETS.RABBIT),
             groups=(),
             collision_sprites=self.collision_sprites,
+            controls=self.controls,
             apply_tool=self.apply_tool,
             plant_collision=self.plant_collision,
             interact=self.interact,
@@ -479,70 +483,63 @@ class Level:
                 self.player.has_horn = True
 
     def handle_event(self, event: pygame.event.Event) -> bool:
-        hitbox_key = self.player.controls.DEBUG_SHOW_HITBOXES.control_value
-        dialog_key = self.player.controls.SHOW_DIALOG.control_value
-        pf_overlay_key = self.player.controls.SHOW_PF_OVERLAY.control_value
-        advance_dialog_key = self.player.controls.ADVANCE_DIALOG.control_value
-        round_end_key = self.player.controls.END_ROUND.control_value
-        player_task_key = self.player.controls.DEDUG_PLAYER_TASK.control_value
-        debug_player_receives_hat = (
-            self.player.controls.DEBUG_PLAYER_RECEIVES_HAT.control_value
-        )
-        debug_player_receives_necklace = (
-            self.player.controls.DEBUG_PLAYER_RECEIVES_NECKLACE.control_value
-        )
-        debug_npc_receives_necklace = (
-            self.player.controls.DEBUG_NPC_RECEIVES_NECKLACE.control_value
-        )
-        debug_decide_tomato_or_corn = (
-            self.player.controls.DEBUG_DECIDE_TOMATO_OR_CORN.control_value
-        )
-
         if self.current_minigame and self.current_minigame.running:
             if self.current_minigame.handle_event(event):
                 return True
 
-        if event.type == pygame.KEYDOWN:
-            if event.key == pygame.K_ESCAPE:
-                self.switch_screen(GameState.PAUSE)
-                return True
-            if event.key == hitbox_key:
-                self.show_hitbox_active = not self.show_hitbox_active
-                return True
-            if event.key == player_task_key:
-                self.switch_screen(GameState.PLAYER_TASK)
-                return True
-            if event.key == dialog_key:
-                post_event(DIALOG_SHOW, dial="test")
-                return True
-            if event.key == advance_dialog_key:
-                post_event(DIALOG_ADVANCE)
-                return True
-            if event.key == pf_overlay_key:
-                self.show_pf_overlay = not self.show_pf_overlay
-                return True
-            if event.key == round_end_key:
-                self.switch_screen(GameState.ROUND_END)
-            if event.key == debug_player_receives_hat:
-                self.start_scripted_sequence(ScriptedSequenceType.PLAYER_RECEIVES_HAT)
-                return True
-            if event.key == debug_player_receives_necklace:
-                self.start_scripted_sequence(
-                    ScriptedSequenceType.PLAYER_RECEIVES_NECKLACE
-                )
-                return True
-            if event.key == debug_npc_receives_necklace:
-                self.start_scripted_sequence(ScriptedSequenceType.NPC_RECEIVES_NECKLACE)
-                return True
-            if event.key == debug_decide_tomato_or_corn:
-                self.start_scripted_sequence(ScriptedSequenceType.DECIDE_TOMATO_OR_CORN)
-                return True
         if event.type == START_QUAKE:
             self.quaker.start(event.duration)
             if event.debug:
                 self.set_round(7)
+            return True
+
+        elif event.type == pygame.KEYDOWN:
+            if event.key == pygame.K_ESCAPE:
+                self.switch_screen(GameState.PAUSE)
+                return True
+            self.controls.update_control_state(event.key, True)
+        elif event.type == pygame.KEYUP:
+            self.controls.update_control_state(event.key, False)
+        elif event.type == pygame.MOUSEBUTTONDOWN:
+            self.controls.update_control_state(event.button, True)
+        elif event.type == pygame.MOUSEBUTTONUP:
+            self.controls.update_control_state(event.button, False)
 
         return False
+
+    def handle_controls(self):
+        if self.controls.ADVANCE_DIALOG.click:
+            post_event(DIALOG_ADVANCE)
+
+        if self.controls.DEBUG_QUAKE.click:
+            post_event(START_QUAKE, duration=2.0, debug=True)
+
+        if self.controls.DEDUG_PLAYER_TASK.click:
+            self.switch_screen(GameState.PLAYER_TASK)
+
+        if self.controls.DEBUG_END_ROUND.click:
+            self.switch_screen(GameState.ROUND_END)
+
+        if self.controls.DEBUG_PLAYER_RECEIVES_HAT.click:
+            self.start_scripted_sequence(ScriptedSequenceType.PLAYER_RECEIVES_HAT)
+
+        if self.controls.DEBUG_PLAYER_RECEIVES_NECKLACE.click:
+            self.start_scripted_sequence(ScriptedSequenceType.PLAYER_RECEIVES_NECKLACE)
+
+        if self.controls.DEBUG_NPC_RECEIVES_NECKLACE.click:
+            self.start_scripted_sequence(ScriptedSequenceType.NPC_RECEIVES_NECKLACE)
+
+        if self.controls.DEBUG_DECIDE_TOMATO_OR_CORN.click:
+            self.start_scripted_sequence(ScriptedSequenceType.DECIDE_TOMATO_OR_CORN)
+
+        if self.controls.DEBUG_SHOW_HITBOXES.click:
+            self.show_hitbox_active = not self.show_hitbox_active
+
+        if self.controls.DEBUG_SHOW_PF_OVERLAY.click:
+            self.show_pf_overlay = not self.show_pf_overlay
+
+        if self.controls.DEBUG_SHOW_DIALOG.click:
+            post_event(DIALOG_SHOW, dial="test")
 
     def start_scripted_sequence(self, sequence_type: ScriptedSequenceType):
         # do not start new scripted sequence when one is already running
@@ -906,6 +903,8 @@ class Level:
 
     def update(self, dt: float, move_things: bool = True):
         # update
+        self.handle_controls()
+
         self.game_time.update()
         self.check_map_exit()
         self.check_outgroup_logic()
@@ -941,3 +940,6 @@ class Level:
 
             self.decay_health()
         self.draw(dt, move_things)
+
+        for control in self.controls:
+            control.click = False

--- a/src/screens/minigames/cow_herding.py
+++ b/src/screens/minigames/cow_herding.py
@@ -41,7 +41,7 @@ def _set_player_controls(controls: Type[Controls], value: bool):
     controls.INVENTORY.disabled = value
     controls.EMOTE_WHEEL.disabled = value
     # overlays are not disabled
-    controls.SHOW_DIALOG.disabled = value
+    controls.DEBUG_SHOW_DIALOG.disabled = value
     controls.ADVANCE_DIALOG.disabled = value
 
 

--- a/src/sprites/entities/player.py
+++ b/src/sprites/entities/player.py
@@ -42,6 +42,7 @@ class Player(Character):
         assets: EntityAsset,
         groups: tuple[pygame.sprite.Group, ...],
         collision_sprites: pygame.sprite.Group,
+        controls: Type[Controls],
         apply_tool: Callable[[FarmingTool, tuple[float, float], Character], None],
         plant_collision: Callable[[Character], None],
         interact: Callable[[], None],
@@ -64,7 +65,7 @@ class Player(Character):
 
         # movement
         self.save_file = save_file
-        self.controls = Controls
+        self.controls = controls
         self.load_controls()
         self.original_speed = 250
         self.speed = 250
@@ -133,26 +134,6 @@ class Player(Character):
         except FileNotFoundError:
             support.save_data(self.controls.as_dict(), "keybinds.json")
 
-    # controls
-    def update_controls(self):
-        keys_just_pressed = pygame.key.get_just_pressed()
-        keys_pressed = pygame.key.get_pressed()
-        mouse_pressed = pygame.mouse.get_pressed()
-
-        for control in self.controls.all_controls():
-            if control.disabled:
-                continue
-
-            is_mouse_event = control.control_value in (1, 2, 3)
-
-            if is_mouse_event:
-                is_event_active = mouse_pressed[control.control_value - 1]
-                control.click = is_event_active and not control.hold
-                control.hold = is_event_active
-            else:
-                control.click = keys_just_pressed[control.control_value]
-                control.hold = keys_pressed[control.control_value]
-
     def assign_seed(self, seed: str):
         computed_value = FarmingTool.from_serialised_string(seed)
         if not computed_value.is_seed():
@@ -166,8 +147,6 @@ class Player(Character):
         self.current_tool = computed_value
 
     def handle_controls(self):
-        self.update_controls()
-
         # the scripted sequence needs the emote_manager to work even when NPC is blocked"""
         if self.emote_manager.emote_wheel.visible:
             if self.controls.RIGHT.click:


### PR DESCRIPTION
## Summary

This PR refactors how Controls is updated by moving its main reference to Level and linking it to the global event loop.

It also fixes a bug where the inventory would instantly be opened again upon closing it with the Inventory control

## Checklist

- [X] I have tested this change locally and it works as expected.
- [X] I have made sure that the code follows the formatting and style guidelines of the project.

## Labels
`area: code-quality`
