### PR TITLE
fix(debug-overlays): Fix hitbox and pf overlay sometimes being offset

### DIFF
--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -882,12 +882,14 @@ class Level:
         self.player.hp = self.overlay.health_bar.hp
         self.display_surface.fill((130, 168, 132))
         self.all_sprites.draw(self.camera)
+
+        self.draw_pf_overlay()
+        self.draw_hitboxes()
+
         self.zoom_manager.apply_zoom()
         if move_things:
             self.sky.display(self.get_round())
 
-        self.draw_pf_overlay()
-        self.draw_hitboxes()
         self.draw_overlay()
 
         if self.current_minigame and self.current_minigame.running:

--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -317,7 +317,6 @@ class Level:
                     collision_sprites=self.collision_sprites,
                     overlay=self.overlay,
                     sounds=self.sounds,
-                    get_camera_center=self.get_camera_center,
                 )
             )
 
@@ -719,11 +718,8 @@ class Level:
         self.cutscene_animation.set_current_animation(DEFAULT_ANIMATION_NAME)
         self.cutscene_animation.is_end_condition_met = lambda: True
 
-    def get_camera_center(self):
-        if self.cutscene_animation:
-            return self.cutscene_animation.get_current_position()
-
-        return self.player.rect.center
+    def get_camera_pos(self):
+        return self.camera.state.topleft
 
     def start_transition(self):
         self.player.blocked = True
@@ -790,9 +786,7 @@ class Level:
     # region debug-overlays
     def draw_hitboxes(self):
         if self.show_hitbox_active:
-            offset = pygame.Vector2(0, 0)
-            offset.x = -(self.get_camera_center()[0] - SCREEN_WIDTH / 2)
-            offset.y = -(self.get_camera_center()[1] - SCREEN_HEIGHT / 2)
+            offset = pygame.Vector2(self.get_camera_pos())
 
             for sprite in self.collision_sprites:
                 rect = sprite.rect.copy()
@@ -830,9 +824,7 @@ class Level:
 
     def draw_pf_overlay(self):
         if self.show_pf_overlay:
-            offset = pygame.Vector2(0, 0)
-            offset.x = -(self.get_camera_center()[0] - SCREEN_WIDTH / 2)
-            offset.y = -(self.get_camera_center()[1] - SCREEN_HEIGHT / 2)
+            offset = pygame.Vector2(self.get_camera_pos())
 
             if AIData.setup:
                 for y in range(len(AIData.Matrix)):

--- a/src/screens/minigames/cow_herding.py
+++ b/src/screens/minigames/cow_herding.py
@@ -53,7 +53,6 @@ class CowHerdingState(MinigameState):
     collision_sprites: PersistentSpriteGroup
     overlay: Overlay
     sounds: SoundDict
-    get_camera_center: Callable[[], pygame.Vector2 | tuple[float, float]]
 
 
 class CowHerding(Minigame):

--- a/src/screens/minigames/cow_herding.py
+++ b/src/screens/minigames/cow_herding.py
@@ -1,4 +1,3 @@
-from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Type
 


### PR DESCRIPTION
## Summary

This PR fixes debugging overlays sometimes being offset as described in issue #143 .

## Checklist

- [X] I have tested this change locally and it works as expected.
- [X] I have made sure that the code follows the formatting and style guidelines of the project.

## Labels
`type: bugfix`, `game-playtesting`
