### PR TITLE
added "group celebrates player's birthday" scripted sequence

### DIFF
--- a/data/dialogues.json
+++ b/data/dialogues.json
@@ -14,6 +14,11 @@
     ["Special event!", "We gather her for a special occasion"],
     ["Special event!", "You have received a necklace!"]
   ],
+  "scripted_sequence_player_receives_necklace_bd": [
+    ["Special event!", "We gather her for a special occasion"],
+    ["Special event!", "Happy birthday!"],
+    ["Special event!", "You have received a special birthday necklace"]
+  ],
   "scripted_sequence_npc_receives_necklace": [
     ["Special event!", "We gather her for a special occasion"],
     ["Special event!", "Our group member received a necklace!"]

--- a/src/controls.py
+++ b/src/controls.py
@@ -97,6 +97,10 @@ class Controls(Control, Enum):
     DEBUG_QUAKE = (pygame.K_m, "Start Earthquake Effect")
     DEBUG_PLAYER_RECEIVES_HAT = (pygame.K_j, "Player receives hat")
     DEBUG_PLAYER_RECEIVES_NECKLACE = (pygame.K_k, "Player receives necklace")
+    DEBUG_PLAYER_RECEIVES_NECKLACE_BD = (
+        pygame.K_o,
+        "Player receives necklace for birthday",
+    )
     DEBUG_NPC_RECEIVES_NECKLACE = (pygame.K_l, "NPC receives necklace")
     DEBUG_DECIDE_TOMATO_OR_CORN = (pygame.K_u, "Decide: tomato or corn")
     EMOTE_WHEEL = (pygame.K_e, "Toggle Emote Wheel")

--- a/src/enums.py
+++ b/src/enums.py
@@ -358,5 +358,6 @@ class ClockVersion(IntEnum):
 class ScriptedSequenceType(StrEnum):
     PLAYER_RECEIVES_HAT = "player_receives_hat"
     PLAYER_RECEIVES_NECKLACE = "player_receives_necklace"
+    PLAYER_RECEIVES_NECKLACE_BD = "player_receives_necklace_bd"
     NPC_RECEIVES_NECKLACE = "npc_receives_necklace"
     DECIDE_TOMATO_OR_CORN = "decide_tomato_or_corn"

--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -151,7 +151,7 @@ class Level:
         # add additional sprites for scripted sequence "decide_tomato_or_corn"
         # extra sprites are fine, which sprites are actually shown on the wheel depends on emote_list param
         for frame in TOMATO_OR_CORN_LIST:
-            self._emotes[frame] = [self.frames["overlay"][frame]]
+            self._emotes[frame] = [self.frames["items"][frame]]
 
         self.player_emote_manager = PlayerEmoteManager(
             self._emotes, EMOTES_LIST, self.all_sprites
@@ -491,6 +491,9 @@ class Level:
         debug_player_receives_necklace = (
             self.player.controls.DEBUG_PLAYER_RECEIVES_NECKLACE.control_value
         )
+        debug_player_receives_necklace_bd = (
+            self.player.controls.DEBUG_PLAYER_RECEIVES_NECKLACE_BD.control_value
+        )
         debug_npc_receives_necklace = (
             self.player.controls.DEBUG_NPC_RECEIVES_NECKLACE.control_value
         )
@@ -529,6 +532,11 @@ class Level:
             if event.key == debug_player_receives_necklace:
                 self.start_scripted_sequence(
                     ScriptedSequenceType.PLAYER_RECEIVES_NECKLACE
+                )
+                return True
+            if event.key == debug_player_receives_necklace_bd:
+                self.start_scripted_sequence(
+                    ScriptedSequenceType.PLAYER_RECEIVES_NECKLACE_BD
                 )
                 return True
             if event.key == debug_npc_receives_necklace:
@@ -619,6 +627,8 @@ class Level:
         if sequence_type == ScriptedSequenceType.PLAYER_RECEIVES_HAT:
             npc.has_hat = True
         elif sequence_type == ScriptedSequenceType.PLAYER_RECEIVES_NECKLACE:
+            npc.has_necklace = True
+        elif sequence_type == ScriptedSequenceType.PLAYER_RECEIVES_NECKLACE_BD:
             npc.has_necklace = True
         elif sequence_type == ScriptedSequenceType.NPC_RECEIVES_NECKLACE:
             npc.has_necklace = True


### PR DESCRIPTION
## Summary

This PR implements "group celebrates player's birthday" scripted sequence.

Press `o` to activate. 
Also, a fix has been applied that solves the bug with loading custom EmoteWheel sprites.

## Checklist

- [x] I have tested this change locally and it works as expected.
- [x] I have made sure that the code follows the formatting and style guidelines of the project.

## Labels
`type: feature`, `area: scripted-sequence`
