### PR TITLE
fix(controls): Make same key controls work again

### DIFF
--- a/src/controls.py
+++ b/src/controls.py
@@ -113,18 +113,18 @@ class Controls(Control, Enum):
     DEBUG_SHOW_DIALOG = (pygame.K_t, "Show Dialog")
 
     @classmethod
-    def get_control_by_value(cls, control_value: int) -> Control | None:
+    def get_by_value(cls, control_value: int) -> Generator[Control, None, None]:
         for i in cls:
             control = cls[i.name]
             if control.control_value == control_value:
-                return control
+                yield control
 
     @classmethod
     def update_control_state(cls, control_value: int, control_held: bool):
-        control = cls.get_control_by_value(control_value)
-        if control and not control.disabled:
-            control.click = control_held
-            control.hold = control_held
+        for control in cls.get_by_value(control_value):
+            if not control.disabled:
+                control.click = control_held
+                control.hold = control_held
 
     @classmethod
     def as_dict(cls) -> dict[str, dict[str, str | int]]:


### PR DESCRIPTION
## Summary

This PR fixes a bug found by @HubertReX where only one control would get updated if multiple controls where bound to the same key.

## Checklist

- [X] I have tested this change locally and it works as expected.
- [X] I have made sure that the code follows the formatting and style guidelines of the project.

## Labels
`type: bugfix`
