### PR TITLE
Fix Key Names Overlapping with their Symbols in Keybinds Settings

### DIFF
--- a/src/gui/menu/components.py
+++ b/src/gui/menu/components.py
@@ -253,6 +253,7 @@ class KeySetup(Component):
         unicode: str,
         pos: tuple[int, int],
         image: pygame.Surface,
+        description_slider_rect : pygame.Rect,
     ):
         # params
         self.name = name
@@ -267,7 +268,7 @@ class KeySetup(Component):
 
         # rect
         self.pos = pos
-        self.rect = pygame.Rect(pos, (300, 50))
+        self.rect = pygame.Rect(pos, (description_slider_rect.width - 75, 50))
         self.offset = vector()
         super().__init__(self.rect)
 

--- a/src/gui/menu/components.py
+++ b/src/gui/menu/components.py
@@ -253,7 +253,7 @@ class KeySetup(Component):
         unicode: str,
         pos: tuple[int, int],
         image: pygame.Surface,
-        description_slider_rect : pygame.Rect,
+        description_slider_rect: pygame.Rect,
     ):
         # params
         self.name = name

--- a/src/gui/menu/description.py
+++ b/src/gui/menu/description.py
@@ -133,7 +133,9 @@ class KeybindsDescription(Description):
             image = pygame.transform.scale(image, (40, 40))
 
             topleft = (10, 10 + 60 * index)
-            key_setup_button = KeySetup(name, control, unicode, topleft, image, self.description_slider_rect)
+            key_setup_button = KeySetup(
+                name, control, unicode, topleft, image, self.description_slider_rect
+            )
             self.keys_group.append(key_setup_button)
 
             index += 1

--- a/src/gui/menu/description.py
+++ b/src/gui/menu/description.py
@@ -133,7 +133,7 @@ class KeybindsDescription(Description):
             image = pygame.transform.scale(image, (40, 40))
 
             topleft = (10, 10 + 60 * index)
-            key_setup_button = KeySetup(name, control, unicode, topleft, image)
+            key_setup_button = KeySetup(name, control, unicode, topleft, image, self.description_slider_rect)
             self.keys_group.append(key_setup_button)
 
             index += 1


### PR DESCRIPTION
This pull request is a fix the problem of overlapping between key names and their symbols in Keybinds Settings

---- **Notes on the Approach**
The approach taken considers the future possibility of the ability to change the window resolution (meaning that the provided spacing between the key name and its symbol is independent from the window width, but rather depends on the Keybinds Section width)

---- **Test with formatlint.py**
I tested the game with formatlint.py and it worked !