### PR TITLE
fix(dialog): use pygbag-friendly Surface dimension methods

### DIFF
--- a/src/gui/interface/dialog.py
+++ b/src/gui/interface/dialog.py
@@ -71,8 +71,8 @@ class TextBox(Sprite):
 
         super().__init__(
             (
-                SCREEN_WIDTH / 2 - self.image.width / 2,
-                SCREEN_HEIGHT - self.image.height,
+                SCREEN_WIDTH / 2 - self.image.get_width() / 2,
+                SCREEN_HEIGHT - self.image.get_height(),
             ),
             self.image,
             (),


### PR DESCRIPTION
.width and .height properties of pygame.Surface objects aren't supported in the pygbag distribution of pygame. The .get_width() and .get_height() method are equivalent and work in pybag context and locally.
