### PR TITLE
#227 bug fixed

### DIFF
--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -599,28 +599,36 @@ class Level:
             # move player other npc_in_center to the meeting point and make him face to the east (right)
             npc_in_center.teleport(meeting_pos)
             # npc_in_center.direction = pygame.Vector2(1, 0)
-            npc_in_center.direction.update((1, 0))
+            if active_group == StudyGroup.INGROUP:
+                npc_in_center.direction.update((1, 0))
+            else:
+                npc_in_center.direction.update((-1, 0))
             npc_in_center.get_facing_direction()
             npc_in_center.direction.update((0, 0))
 
             # spread all ingroup npc in half-circle of 2 * SCALED_TILE_SIZE diameter
             # from north to south clockwise or counterclockwise (depends on group)
             # and make them face the player in the center
-            distance = pygame.Vector2(0, -2 * SCALED_TILE_SIZE)
-            rot_by = (180) / (len(npcs) - 1)
-            # the outgroup circle is layed out counterclockwise
-            if active_group == StudyGroup.OUTGROUP:
-                rot_by = -rot_by
-            angle = 0.0
+            if len(npcs) > 0:
+                distance = pygame.Vector2(0, -2 * SCALED_TILE_SIZE)
+                if len(npcs) == 1:
+                    rot_by = 0.0
+                    angle = -90.0
+                else:
+                    rot_by = (180) / (len(npcs) - 1)
+                    angle = 0.0
+                # the outgroup circle is laid out counterclockwise
+                if active_group == StudyGroup.OUTGROUP:
+                    rot_by = -rot_by
 
-            for npc in npcs:
-                new_pos = meeting_pos + distance.rotate(angle)
-                npc.direction.update(-distance.rotate(angle))
-                npc.get_facing_direction()
-                npc.direction.update((0, 0))
+                for npc in npcs:
+                    new_pos = meeting_pos + distance.rotate(angle)
+                    npc.direction.update(-distance.rotate(angle))
+                    npc.get_facing_direction()
+                    npc.direction.update((0, 0))
 
-                npc.teleport(new_pos)
-                angle += rot_by
+                    npc.teleport(new_pos)
+                    angle += rot_by
             self.cutscene_animation.reset()
             self.cutscene_animation.start()
 

--- a/src/screens/switch_to_outgroup_menu.py
+++ b/src/screens/switch_to_outgroup_menu.py
@@ -25,8 +25,6 @@ class OutgroupMenu(GeneralMenu):
     def button_action(self, text):
         if "Yes" in text:
             self.player.study_group = StudyGroup.OUTGROUP
-            self.player.has_hat = False
-            self.player.has_necklace = False
             self.switch_screen(GameState.PLAY)
         elif "No" in text:
             self.switch_screen(GameState.PLAY)

--- a/src/sprites/entities/character.py
+++ b/src/sprites/entities/character.py
@@ -165,6 +165,17 @@ class Character(Entity, ABC):
                 skin_frame = skin_ani.get_frame(self.frame_index)
                 skin_frame.set_alpha(self.image_alpha)
                 blit_list.append((skin_frame, rect))
+            else:
+                # if transition to outgroup has not finished, drew the ingroup body
+                self.image.set_alpha(self.image_alpha)
+                super().draw(display_surface, rect, camera)
+
+                if self.has_hat:
+                    hat_state = EntityState(f"hat_{self.state.value}")
+                    hat_ani = self.assets[hat_state][self.facing_direction]
+                    hat_frame = hat_ani.get_frame(self.frame_index)
+                    hat_frame.set_alpha(self.image_alpha)
+                    blit_list.append((hat_frame, rect))
 
             if self.has_horn:
                 horn_state = EntityState(f"horn_{self.state.value}")


### PR DESCRIPTION
## Summary

This PR fixes Bug #227 with player disappearing.

The logic is as follows:

- After spending 30 sec inside outgroup area, a menu with question about group change is shown
- If the player chooses "yes", they should lose their necklace immediately
- He will lose the hat after another minute (i.e. one minute after choosing "Yes")
- He will get the same colour as the (former) outgroup after another minute (i.e. two minutes after choosing "yes") - slowly fading out from old color and then fading in with new color
- Then, after another minute (i.e. three minutes after choosing "yes"), he gets the horn

The body should be visible at all times.

## Checklist

- [x] I have tested this change locally and it works as expected.
- [x] I have made sure that the code follows the formatting and style guidelines of the project.

## Labels
`type: bug`, `area: gameplay`