### PR TITLE
Fix Tutorial Bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -396,7 +396,10 @@ class Game:
 
             # Into and Tutorial
             self.show_intro_msg()
-            if not self.player.save_file.is_tutorial_completed:
+            if (
+                not self.player.save_file.is_tutorial_completed
+                and not self.level.cutscene_animation.active
+            ):
                 self.tutorial.update(is_game_paused)
 
             mouse_pos = pygame.mouse.get_pos()

--- a/src/tutorial/tutorial.py
+++ b/src/tutorial/tutorial.py
@@ -121,7 +121,6 @@ class Tutorial:
                 if (
                     0 not in self.movement_axis
                     and self.dialogue_manager._get_current_tb().finished_advancing
-                    and not self.level.cutscene_animation.active
                 ):
                     self.switch_to_task(1)
                     self.tasks_achieved += 1


### PR DESCRIPTION
This Pull Request resolves the bug mentioned in issue #250.

### **Approach**
By calling the tutorial method "update" once the cutscene finishes, we can prevent checking the text box (which was the heart of the bug), the player movement and in general any condition upon which the tutorial text box will switch or disappear during the cutscene animation.
