### PR TITLE
Bug: hide FPS overlay panel when game version is not DEBUG #255

### DIFF
--- a/main.py
+++ b/main.py
@@ -150,7 +150,7 @@ class Game:
         self.shop_menu = None
         self.settings_menu = None
         if not USE_SERVER:
-            self.set_token({"token": "123", "jwt": "dummy_token", "game_version": 0})
+            self.set_token({"token": "123", "jwt": "dummy_token", "game_version": 1})
 
         self.token_status = False
         self.allocation_task = PlayerTask(self.send_resource_allocation)

--- a/main.py
+++ b/main.py
@@ -150,7 +150,7 @@ class Game:
         self.shop_menu = None
         self.settings_menu = None
         if not USE_SERVER:
-            self.set_token({"token": "000", "jwt": "dummy_token", "game_version": 0})
+            self.set_token({"token": "123", "jwt": "dummy_token", "game_version": 0})
 
         self.token_status = False
         self.allocation_task = PlayerTask(self.send_resource_allocation)

--- a/src/overlay/overlay.py
+++ b/src/overlay/overlay.py
@@ -35,6 +35,7 @@ class Overlay:
         self.FPS = FPS(clock)
 
         self.round_config = round_config
+        self.is_debug_mode_version: bool = False
 
     def display(self):
         if not self.visible:
@@ -51,7 +52,8 @@ class Overlay:
         self.display_surface.blit(tool_surf, tool_rect)
 
         self.clock.display()
-        self.FPS.display()
+        if self.is_debug_mode_version:
+            self.FPS.display()
 
         # health bar
         if self.round_config.get("healthbar", False):

--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -255,6 +255,7 @@ class Level:
         self.hide_bath_signs()
         self.player.round_config_changed(round_config)
         self.overlay.round_config = round_config
+        self.overlay.is_debug_mode_version = self.get_game_version() == DEBUG_MODE_VERSION
         self.game_map.round_config_changed(round_config)
 
     def load_map(self, game_map: Map, from_map: str = None):

--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -255,7 +255,9 @@ class Level:
         self.hide_bath_signs()
         self.player.round_config_changed(round_config)
         self.overlay.round_config = round_config
-        self.overlay.is_debug_mode_version = self.get_game_version() == DEBUG_MODE_VERSION
+        self.overlay.is_debug_mode_version = (
+            self.get_game_version() == DEBUG_MODE_VERSION
+        )
         self.game_map.round_config_changed(round_config)
 
     def load_map(self, game_map: Map, from_map: str = None):


### PR DESCRIPTION
## Summary

This PR fixes #255.

## Checklist

- [x] I have tested this change locally and it works as expected.
- [x] I have made sure that the code follows the formatting and style guidelines of the project.

## Labels
`type: bugfix`, `area: overlay`