### PR TITLE
removed the ability to re-assign keybindings in the options menu

### DIFF
--- a/src/screens/menu_settings.py
+++ b/src/screens/menu_settings.py
@@ -38,7 +38,7 @@ class SettingsMenu(GeneralMenu):
         )  # used to be self.keybinds_description
 
         # buttons
-        self.buttons.append(self.keybinds_description.reset_button)
+        # self.buttons.append(self.keybinds_description.reset_button)
         self.show_debug_keybinds: bool = False
 
     def round_config_changed(self, round_config: dict[str, Any]) -> None:

--- a/src/screens/menu_settings.py
+++ b/src/screens/menu_settings.py
@@ -7,7 +7,7 @@ from pygame.math import Vector2 as vector
 from src import settings
 from src.controls import Controls
 from src.enums import GameState
-from src.gui.menu.description import KeybindsDescription, VolumeDescription
+from src.gui.menu.description import VolumeDescription  # , KeybindsDescription
 from src.gui.menu.general_menu import GeneralMenu
 from src.settings import DEBUG_MODE_VERSION, SCREEN_HEIGHT, SCREEN_WIDTH
 from src.support import get_translated_string as _
@@ -21,7 +21,7 @@ class SettingsMenu(GeneralMenu):
         controls: Type[Controls],
         get_game_version: Callable[[], int],
     ):
-        options = [_("Keybinds"), _("Volume"), _("Back")]
+        options = [_("Volume"), _("Back")]  # used to include _("Keybinds"),
         title = _("Settings")
         size = (400, 400)
         switch = switch_screen
@@ -31,9 +31,11 @@ class SettingsMenu(GeneralMenu):
 
         # description
         description_pos = self.rect.topright + vector(100, 0)
-        self.keybinds_description = KeybindsDescription(description_pos, controls)
+        # self.keybinds_description = KeybindsDescription(description_pos, controls)
         self.volume_description = VolumeDescription(description_pos, sounds)
-        self.current_description = self.keybinds_description
+        self.current_description = (
+            self.volume_description
+        )  # used to be self.keybinds_description
 
         # buttons
         self.buttons.append(self.keybinds_description.reset_button)
@@ -42,22 +44,22 @@ class SettingsMenu(GeneralMenu):
     def round_config_changed(self, round_config: dict[str, Any]) -> None:
         self.round_config = round_config
         self.show_debug_keybinds = self.get_game_version() == DEBUG_MODE_VERSION
-        self.keybinds_description.create_keybinds(self.show_debug_keybinds)
+        # self.keybinds_description.create_keybinds(self.show_debug_keybinds)
 
     # setup
     def button_action(self, text: str):
         self.current_description.reset()
 
-        if text == _("Keybinds"):
-            self.current_description = self.keybinds_description
+        # if text == _("Keybinds"):
+        #     self.current_description = self.keybinds_description
         if text == _("Volume"):
             self.current_description = self.volume_description
         if text == _("Back"):
-            self.keybinds_description.save_data()
+            # self.keybinds_description.save_data()
             self.volume_description.save_data()
             self.switch_screen(GameState.PAUSE)
         if text == _("Reset"):
-            self.keybinds_description.reset_keybinds(self.show_debug_keybinds)
+            # self.keybinds_description.reset_keybinds(self.show_debug_keybinds)
             self.volume_description.reset_volumes()
 
     # events
@@ -83,5 +85,5 @@ class SettingsMenu(GeneralMenu):
 
     # update
     def update(self, dt: float):
-        self.keybinds_description.update_keybinds(dt)
+        # self.keybinds_description.update_keybinds(dt)
         super().update(dt)


### PR DESCRIPTION
## Summary

This PR resolves #287 and prepares for #275 (displaying key bindings statically). If the functionality of assigning key bindings is later desired and the display loads them dynamically, they can easily be returned (the functionality remains in the source but is commented out) 

## Checklist

- [x] I have tested this change locally and it works as expected.
- [x] I have made sure that the code follows the formatting and style guidelines of the project.
<!-- - [ ] Since this PR modifies related documentation, I have proofread files for spelling and grammar errors. -->

## Labels
`type: bugfix` `type: revert` `game-ui`
