### PR TITLE
Watering Tutorial Bugfix

### DIFF
--- a/src/overlay/soil.py
+++ b/src/overlay/soil.py
@@ -330,20 +330,20 @@ class SoilArea:
 
         WARNING: this method is for internal usage.
         Use SoilLayer.water instead."""
-        if tile is not None and tile.hoed and not tile.watered:
-            tile.watered = True
+        if tile is not None and tile.hoed:
+            if not tile.watered:
+                tile.watered = True
 
-            water_frames = list(self.level_frames["soil water"].values())
-            water_frame = choice(water_frames)
-            water = Sprite(
-                tile_to_screen(tile.pos),
-                water_frame,
-                (),
-                Layer.SOIL_WATER,
-            )
-            water.add(self.all_sprites, self.water_sprites)
+                water_frames = list(self.level_frames["soil water"].values())
+                water_frame = choice(water_frames)
+                water = Sprite(
+                    tile_to_screen(tile.pos),
+                    water_frame,
+                    (),
+                    Layer.SOIL_WATER,
+                )
+                water.add(self.all_sprites, self.water_sprites)
             return True
-
         return False
 
     def water(self, pos):

--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -468,10 +468,7 @@ class Level:
             case FarmingTool.WATERING_CAN:
                 if self.soil_manager.water(character, pos):
                     # check if the player achieved task "water the crop"
-                    if (
-                        isinstance(character, Player)
-                        and True in self.crop_planted
-                    ):
+                    if isinstance(character, Player) and True in self.crop_planted:
                         self.crop_watered = True
 
                 self._play_playeronly_sound("water", character)

--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -471,7 +471,6 @@ class Level:
                     if (
                         isinstance(character, Player)
                         and True in self.crop_planted
-                        and pos in self.crop_planted
                     ):
                         self.crop_watered = True
 


### PR DESCRIPTION
## Summary
Fixes #289 

The watering function now returns true if you water a valid tile (which is hoed) even when it is already watered. This only changes the behaviour of the watering tutorial (which previously became impossible once an NPC watered a tile). Additionally, the watering tutorial is not bound to the tile which was planted by the player.

## Checklist

- [x] I have tested this change locally and it works as expected.
- [x] I have made sure that the code follows the formatting and style guidelines of the project.

## Labels
`type: bugfix`
