### PR TITLE
Added overwritten code after merging pr 283

### DIFF
--- a/main.py
+++ b/main.py
@@ -633,10 +633,10 @@ class Game:
                         self.round_config["notify_new_crop_text"] = ""
                         self.round_config["notify_new_crop_timestamp"] = []
                     elif (
-                            self.round_config.get("notify_questionnaire_text", "")
-                            and self.round_config["notify_questionnaire_timestamp"]
-                            and self.round_end_timer
-                            > self.round_config["notify_questionnaire_timestamp"][0]
+                        self.round_config.get("notify_questionnaire_text", "")
+                        and self.round_config["notify_questionnaire_timestamp"]
+                        and self.round_end_timer
+                        > self.round_config["notify_questionnaire_timestamp"][0]
                     ):
                         # make a copy of a string
                         message = self.round_config["notify_questionnaire_text"][:]

--- a/main.py
+++ b/main.py
@@ -633,6 +633,19 @@ class Game:
                         self.round_config["notify_new_crop_text"] = ""
                         self.round_config["notify_new_crop_timestamp"] = []
                     elif (
+                            self.round_config.get("notify_questionnaire_text", "")
+                            and self.round_config["notify_questionnaire_timestamp"]
+                            and self.round_end_timer
+                            > self.round_config["notify_questionnaire_timestamp"][0]
+                    ):
+                        # make a copy of a string
+                        message = self.round_config["notify_questionnaire_text"][:]
+                        self.notification_menu.message = message
+                        self.switch_state(GameState.NOTIFICATION_MENU)
+                        # set to empty to not repeat
+                        self.round_config["notify_questionnaire_text"] = ""
+                        self.round_config["notify_questionnaire_timestamp"] = []
+                    elif (
                         self.round_config.get("notify_round_end_outgroup_text", "")
                         and self.round_config["notify_round_end_outgroup_timestamp"]
                         and self.round_end_timer


### PR DESCRIPTION
## Summary

This PR fixes a problem with missing code during the merging of PR [283.](https://github.com/sloukit/pydew-valley-uzh/pull/283)

![Zrzut ekranu 2025-01-27 143459](https://github.com/user-attachments/assets/afe7c42b-3571-45ec-a1f9-e8512160e2bc)

## Checklist

- [x] I have tested this change locally and it works as expected.
- [x] I have made sure that the code follows the formatting and style guidelines of the project.

## Labels
`type: bugfix`
