### PR TITLE
bugfix npc creation in minigame

### DIFF
--- a/src/screens/minigames/cow_herding.py
+++ b/src/screens/minigames/cow_herding.py
@@ -196,6 +196,9 @@ class CowHerding(Minigame):
             emote_manager=self._state.game_map.npc_emote_manager,
             tree_sprites=pygame.sprite.Group(),
             sickness_allowed=self.round_config.get("sickness", False),
+            has_hat=False,
+            has_necklace=False,
+            special_features=None,
         )
         opponent.probability_to_get_sick = 1
         self._state.game_map.npcs.append(opponent)


### PR DESCRIPTION
Please go the the `Preview` tab and select the appropriate sub-template:

Fixes minigame bug after NPC class was edited but in minigame the new attributes were not passed to the constructor. Fixes #297 