### PR TITLE
using function get_width instead of direct variable, hoping to fix on…

### DIFF
--- a/src/gui/interface/emotes.py
+++ b/src/gui/interface/emotes.py
@@ -90,10 +90,10 @@ class EmoteBox(EmoteBoxBase):
         self.image.blit(
             self._current_emote_image,
             (
-                EmoteBox.EMOTE_DIALOG_BOX.width / 2
-                - self._current_emote_image.width / 2,
-                EmoteBox.EMOTE_DIALOG_BOX.height / 2
-                - self._current_emote_image.height / 2
+                EmoteBox.EMOTE_DIALOG_BOX.get_width() / 2
+                - self._current_emote_image.get_width() / 2,
+                EmoteBox.EMOTE_DIALOG_BOX.get_height() / 2
+                - self._current_emote_image.get_height() / 2
                 - 8,
             ),
         )


### PR DESCRIPTION
Trying to fix online error where emotewheel crashes the game because of an unvailable width-attribute


<!-- elaborate more on the changes made, if necessary -->

<!-- ## Media
Add screenshots or videos if applicable, otherwise delete this section -->

## Checklist

- [x] I have tested this change locally and it works as expected.
- [x] I have made sure that the code follows the formatting and style guidelines of the project.
<!-- - [ ] Since this PR modifies related documentation, I have proofread files for spelling and grammar errors. -->


