### PR TITLE
more of the same .width replaced by .get_width()

### DIFF
--- a/src/screens/minigames/cow_herding_overlay.py
+++ b/src/screens/minigames/cow_herding_overlay.py
@@ -221,8 +221,8 @@ class _CowHerdingOverlay:
         self.display_surface.blit(
             rendered_text,
             (
-                SCREEN_WIDTH / 2 - rendered_text.width / 2,
-                SCREEN_HEIGHT / 3 - rendered_text.height / 2,
+                SCREEN_WIDTH / 2 - rendered_text.get_width() / 2,
+                SCREEN_HEIGHT / 3 - rendered_text.get_height() / 2,
             ),
         )
 


### PR DESCRIPTION
Same as the previous 2 PRs, still fixing the direct access bug for surfaces. Since Rect do have the width and height attribute, it is not super easy to catch all of them at once.
