### PR TITLE
fix bug #327

### DIFF
--- a/src/screens/game_map.py
+++ b/src/screens/game_map.py
@@ -717,7 +717,9 @@ class GameMap:
 
         npc = NPC(
             pos=pos,
-            assets=copy.deepcopy(ENTITY_ASSETS.RABBIT),
+            assets=ENTITY_ASSETS.RABBIT
+            if gmap == Map.MINIGAME
+            else copy.deepcopy(ENTITY_ASSETS.RABBIT),
             groups=(self.all_sprites, self.collision_sprites),
             collision_sprites=self.collision_sprites,
             study_group=study_group,

--- a/src/screens/minigames/cow_herding.py
+++ b/src/screens/minigames/cow_herding.py
@@ -1,3 +1,4 @@
+import copy
 import glob
 import random
 
@@ -186,7 +187,7 @@ class CowHerding(Minigame):
         )
         opponent = NPC(
             pos=(0, 0),
-            assets=ENTITY_ASSETS.RABBIT,
+            assets=copy.deepcopy(ENTITY_ASSETS.RABBIT),
             groups=(self._state.all_sprites, self._state.collision_sprites),
             collision_sprites=self._state.collision_sprites,
             study_group=opponent_study_group,


### PR DESCRIPTION
This PR fixes the problem described in issue #327.

When playing online in Game Version 1 or Game Version 2, the game will crash when the player enters the mini-game map for the fifth consecutive time.



[x] I have tested this change on the local server and it works as expected.
[x] I have made sure that the code follows the formatting and style guidelines of the project.