### PR TITLE
Update emote wheel from 8 to 5 emotes

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -125,12 +125,9 @@ BATH_STATUS_TIMEOUT = 30
 DEFAULT_ANIMATION_NAME = "intro"
 
 EMOTES_LIST = [
-    "cheer_ani",
-    "cool_ani",
     "furious_ani",
     "love_ani",
     "sad_ani",
-    "sleep_ani",
     "smile_ani",
     "wink_ani",
 ]


### PR DESCRIPTION
In consultation with @sloukit, the emotion wheel has been edited. Three of the eight emoticons have been removed: cheer_ani, cool_ani, sleep_ani.


![Zrzut ekranu 2025-02-28 201300](https://github.com/user-attachments/assets/d26647a0-e66b-41be-91b7-19174d2af593)


[x] I have tested this change on the local server and it works as expected.
[x] I have made sure that the code follows the formatting and style guidelines of the project.