### PR TITLE
Fix bug from issue #335

### DIFF
--- a/main.py
+++ b/main.py
@@ -75,7 +75,7 @@ print(f"gc.get_threshold: {gc.get_threshold()}")
 
 print("setting new threshold:")
 allocs, g1, g2 = gc.get_threshold()
-gc.set_threshold(50000, g1, g2)
+# gc.set_threshold(50000, g1, g2)
 print(f"gc.get_threshold: {gc.get_threshold()}")
 
 

--- a/src/screens/game_map.py
+++ b/src/screens/game_map.py
@@ -1,4 +1,3 @@
-import copy
 import warnings
 from collections.abc import Callable
 from typing import Any
@@ -717,9 +716,7 @@ class GameMap:
 
         npc = NPC(
             pos=pos,
-            assets=ENTITY_ASSETS.RABBIT
-            if gmap == Map.MINIGAME
-            else copy.deepcopy(ENTITY_ASSETS.RABBIT),
+            assets=ENTITY_ASSETS.RABBIT,
             groups=(self.all_sprites, self.collision_sprites),
             collision_sprites=self.collision_sprites,
             study_group=study_group,

--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -1,4 +1,3 @@
-import copy
 import gc
 import random
 import time
@@ -192,7 +191,7 @@ class Level:
 
         self.player = Player(
             pos=(0, 0),
-            assets=copy.deepcopy(ENTITY_ASSETS.RABBIT),
+            assets=ENTITY_ASSETS.RABBIT,
             groups=(),
             collision_sprites=self.collision_sprites,
             controls=self.controls,

--- a/src/screens/menu_round_end.py
+++ b/src/screens/menu_round_end.py
@@ -1,3 +1,4 @@
+import gc
 from collections.abc import Callable
 from typing import Any
 
@@ -157,6 +158,7 @@ class RoundMenu(GeneralMenu):
     def close(self):
         self.send_telemetry(self.telemetry)
         self.switch_screen(GameState.PLAY)
+        gc.collect()
 
     def button_action(self, text: str):
         if text == _("continue to next round"):

--- a/src/screens/minigames/cow_herding.py
+++ b/src/screens/minigames/cow_herding.py
@@ -1,4 +1,3 @@
-import copy
 import glob
 import random
 
@@ -187,7 +186,7 @@ class CowHerding(Minigame):
         )
         opponent = NPC(
             pos=(0, 0),
-            assets=copy.deepcopy(ENTITY_ASSETS.RABBIT),
+            assets=ENTITY_ASSETS.RABBIT,
             groups=(self._state.all_sprites, self._state.collision_sprites),
             collision_sprites=self._state.collision_sprites,
             study_group=opponent_study_group,

--- a/src/sprites/setup.py
+++ b/src/sprites/setup.py
@@ -1,6 +1,7 @@
 import os
 from dataclasses import dataclass
 from types import SimpleNamespace
+from weakref import WeakValueDictionary
 
 import pygame
 
@@ -24,7 +25,10 @@ class _AniFrames:
         return len(self.frames)
 
 
-type EntityAsset = dict[EntityState, dict[Direction, _AniFrames]]
+# type EntityAsset = dict[EntityState, dict[Direction, _AniFrames]]
+type EntityAsset = WeakValueDictionary[
+    EntityState, WeakValueDictionary[Direction, _AniFrames]
+]
 
 
 class _Hitbox:


### PR DESCRIPTION
This PR fixes a bug from issue #335.
It contains cleaning memory with any level transition, weak references for rabbit assets, and turning off the deep copy for rabbits.  This is a temporary solution, implemented in consultation with @sloukit due to the small amount of time. It's necessary to revert the deep copy and increase the memory in the second part of the project.

[x] I have tested this change on the local server and it works as expected.
[x] I have made sure that the code follows the formatting and style guidelines of the project.