### PR TITLE
Manuel telemetry enhancements

### DIFF
--- a/src/screens/game_map.py
+++ b/src/screens/game_map.py
@@ -975,7 +975,7 @@ class GameMap:
                     payload["emote_index"]
                 ]
                 payload["player_pos"] = ", ".join(str(round(v)) for v in self.player.rect.topleft)
-                payload["npc_pos"] = ", ".join(str(round(v)) for v in self.npc.rect.topleft)
+                payload["npc_pos"] = ", ".join(str(round(v)) for v in npc.rect.topleft)
 
 
                 if self.player.study_group == npc.study_group:

--- a/src/screens/game_map.py
+++ b/src/screens/game_map.py
@@ -970,13 +970,16 @@ class GameMap:
                 # check if the player achieved task "interact with an ingroup member" or "interact
                 # with an outgroup member"
                 payload = {}
-                payload["emote_index"] = self.player_emote_manager.emote_wheel.emote_index
+                payload["emote_index"] = (
+                    self.player_emote_manager.emote_wheel.emote_index
+                )
                 payload["emote_name"] = self.player_emote_manager.emote_wheel._emotes[
                     payload["emote_index"]
                 ]
-                payload["player_pos"] = ", ".join(str(round(v)) for v in self.player.rect.topleft)
+                payload["player_pos"] = ", ".join(
+                    str(round(v)) for v in self.player.rect.topleft
+                )
                 payload["npc_pos"] = ", ".join(str(round(v)) for v in npc.rect.topleft)
-
 
                 if self.player.study_group == npc.study_group:
                     self.player.ingroup_member_interacted = True

--- a/src/screens/game_map.py
+++ b/src/screens/game_map.py
@@ -974,6 +974,9 @@ class GameMap:
                 payload["emote_name"] = self.player_emote_manager.emote_wheel._emotes[
                     payload["emote_index"]
                 ]
+                payload["player_pos"] = ", ".join(str(round(v)) for v in self.player.rect.topleft)
+                payload["npc_pos"] = ", ".join(str(round(v)) for v in self.npc.rect.topleft)
+
 
                 if self.player.study_group == npc.study_group:
                     self.player.ingroup_member_interacted = True

--- a/src/screens/game_map.py
+++ b/src/screens/game_map.py
@@ -969,10 +969,20 @@ class GameMap:
 
                 # check if the player achieved task "interact with an ingroup member" or "interact
                 # with an outgroup member"
+                payload = {}
+                payload["emote_index"] = self.player_emote_manager.emote_wheel.emote_index
+                payload["emote_name"] = self.player_emote_manager.emote_wheel._emotes[
+                    payload["emote_index"]
+                ]
+
                 if self.player.study_group == npc.study_group:
                     self.player.ingroup_member_interacted = True
+                    payload["emote_target"] = "ingroup"
                 else:
                     self.player.outgroup_member_interacted = True
+                    payload["emote_target"] = "outgroup"
+
+                self.player.send_telemetry("player_interaction", payload)
 
         @self.player_emote_manager.on_emote_wheel_opened
         def on_emote_wheel_opened():

--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -417,6 +417,7 @@ class Level:
 
     def switch_to_map(self, map_name: Map):
         if self.tmx_maps.get(map_name):
+            self.send_telemetry("switch_map", {"old_map": self.current_map, "new_map": map_name})
             self.load_map(map_name, from_map=self.current_map)
             self.hide_bath_signs()
             self.game_map.process_npc_round_config()

--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -417,7 +417,7 @@ class Level:
 
     def switch_to_map(self, map_name: Map):
         if self.tmx_maps.get(map_name):
-            self.send_telemetry("switch_map", {"old_map": self.current_map, "new_map": map_name})
+            self.send_telemetry("switch_map", {"old_map": str(self.current_map), "new_map": str(map_name)})
             self.load_map(map_name, from_map=self.current_map)
             self.hide_bath_signs()
             self.game_map.process_npc_round_config()

--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -47,9 +47,9 @@ from src.settings import (
     SCREEN_HEIGHT,
     SCREEN_WIDTH,
     TOMATO_OR_CORN_LIST,
+    TOOLS_LOG_INTERVAL,
     MapDict,
     SoundDict,
-    TOOLS_LOG_INTERVAL,
 )
 from src.sprites.base import Sprite
 from src.sprites.entities.character import Character
@@ -419,7 +419,10 @@ class Level:
 
     def switch_to_map(self, map_name: Map):
         if self.tmx_maps.get(map_name):
-            self.send_telemetry("switch_map", {"old_map": str(self.current_map), "new_map": str(map_name)})
+            self.send_telemetry(
+                "switch_map",
+                {"old_map": str(self.current_map), "new_map": str(map_name)},
+            )
             self.load_map(map_name, from_map=self.current_map)
             self.hide_bath_signs()
             self.game_map.process_npc_round_config()
@@ -508,7 +511,6 @@ class Level:
             self.tool_statistics[tool_use_for_statistics] += 1
             if sum(self.tool_statistics.values()) % TOOLS_LOG_INTERVAL == 0:
                 self.send_telemetry("tool_statistics", self.tool_statistics)
-
 
     def interact(self):
         collided_interactions = pygame.sprite.spritecollide(

--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -49,6 +49,7 @@ from src.settings import (
     TOMATO_OR_CORN_LIST,
     MapDict,
     SoundDict,
+    TOOLS_LOG_INTERVAL,
 )
 from src.sprites.base import Sprite
 from src.sprites.entities.character import Character
@@ -166,6 +167,7 @@ class Level:
 
         self.camera = Camera(0, 0)
         self.quaker = Quaker(self.camera)
+        self.tool_statistics = {t.name: 0 for t in FarmingTool}
 
         self.soil_manager = SoilManager(self.all_sprites, self.frames["level"])
 
@@ -258,7 +260,7 @@ class Level:
 
         # watch the player behaviour in achieving tutorial tasks
         self.tile_farmed = False
-        self.crop_planted: set = set()
+        self.crop_planted = False
         self.crop_watered = False
         self.had_slept = False
         self.hit_tree = False
@@ -453,6 +455,7 @@ class Level:
             self.sounds[sound].play()
 
     def apply_tool(self, tool: FarmingTool, pos: tuple[int, int], character: Character):
+        tool_use_for_statistics = None
         match tool:
             case FarmingTool.AXE:
                 for tree in pygame.sprite.spritecollide(
@@ -468,6 +471,7 @@ class Level:
                     # check if player achieved task "go to the forest and hit a tree"
                     if isinstance(character, Player):
                         self.hit_tree = True
+                        tool_use_for_statistics = tool.name
 
                     self._play_playeronly_sound("axe", character)
             case FarmingTool.HOE:
@@ -477,11 +481,14 @@ class Level:
                     # check if the player achieved task "farm with your hoe"
                     if isinstance(character, Player):
                         self.tile_farmed = True
+                        tool_use_for_statistics = tool.name
             case FarmingTool.WATERING_CAN:
                 if self.soil_manager.water(character, pos):
                     # check if the player achieved task "water the crop"
-                    if isinstance(character, Player) and True in self.crop_planted:
-                        self.crop_watered = True
+                    if isinstance(character, Player):
+                        tool_use_for_statistics = tool.name
+                        if self.crop_planted:
+                            self.crop_watered = True
 
                 self._play_playeronly_sound("water", character)
             case _:  # All seeds
@@ -492,10 +499,16 @@ class Level:
 
                     # check if the player achieved task "plant a crop"
                     if isinstance(character, Player):
-                        self.crop_planted.add(True)
-                        self.crop_planted.add(pos)
+                        self.crop_planted = True
+                        tool_use_for_statistics = tool.name
                 else:
                     self._play_playeronly_sound("cant_plant", character)
+
+        if tool_use_for_statistics is not None:
+            self.tool_statistics[tool_use_for_statistics] += 1
+            if sum(self.tool_statistics.values()) % TOOLS_LOG_INTERVAL == 0:
+                self.send_telemetry("tool_statistics", self.tool_statistics)
+
 
     def interact(self):
         collided_interactions = pygame.sprite.spritecollide(

--- a/src/screens/minigames/cow_herding.py
+++ b/src/screens/minigames/cow_herding.py
@@ -249,6 +249,7 @@ class CowHerding(Minigame):
                 self._state.player.money -= 200
             else:
                 self._state.player.money = 0  # make sure we do not go below 0
+            self._state.player.send_telemetry("minigame_complete", {"self_time": f"{self._minigame_time:.2f}", "opp_time": f"{self._opponent_side_script.total_time:.2f}"})
             self.scoreboard.setup(
                 self._minigame_time,
                 self._player_side.cows_herded_in,

--- a/src/screens/minigames/cow_herding.py
+++ b/src/screens/minigames/cow_herding.py
@@ -249,7 +249,13 @@ class CowHerding(Minigame):
                 self._state.player.money -= 200
             else:
                 self._state.player.money = 0  # make sure we do not go below 0
-            self._state.player.send_telemetry("minigame_complete", {"self_time": f"{self._minigame_time:.2f}", "opp_time": f"{self._opponent_side_script.total_time:.2f}"})
+            self._state.player.send_telemetry(
+                "minigame_complete",
+                {
+                    "self_time": f"{self._minigame_time:.2f}",
+                    "opp_time": f"{self._opponent_side_script.total_time:.2f}",
+                },
+            )
             self.scoreboard.setup(
                 self._minigame_time,
                 self._player_side.cows_herded_in,

--- a/src/settings.py
+++ b/src/settings.py
@@ -46,9 +46,10 @@ USE_SERVER = True
 # position is normally only logged after movement and when the character stands still
 # this is the minimum accumulated moving time to trigger logging for this scenario, to reduce server load
 POS_MIN_LOG_INTERVAL = 1
-
 # if a player moves for a long time continuously, we log the position during movement
 POS_MOVE_LOG_INTERVAL = 15
+# tool log interval after n accumulative uses of all tools and seeds, the statistics are sent to the server
+TOOLS_LOG_INTERVAL = 5
 
 IS_WEB = sys.platform in ("emscripten", "wasm")
 # for now, in web mode, do not use dummy server (which requires `requests` module not available via pygbag)
@@ -58,6 +59,7 @@ if not IS_WEB:
         USE_SERVER = True
     else:
         USE_SERVER = True
+
 
 # NOTE(larsbutler): Don't change this line at all.
 # WEB_SERVER_URL is populated during build,

--- a/src/settings.py
+++ b/src/settings.py
@@ -42,8 +42,13 @@ SECONDS_PER_GAME_MINUTE = 0.7
 WORLD_TIME_MULTIPLIER = 1.0
 # USE_SERVER = False
 USE_SERVER = True
-# position logging interval (in seconds), lowering this may lead to server issues
-POS_LOG_INTERVAL = 3
+
+# position is normally only logged after movement and when the character stands still
+# this is the minimum accumulated moving time to trigger logging for this scenario, to reduce server load
+POS_MIN_LOG_INTERVAL = 1
+
+# if a player moves for a long time continuously, we log the position during movement
+POS_MOVE_LOG_INTERVAL = 15
 
 IS_WEB = sys.platform in ("emscripten", "wasm")
 # for now, in web mode, do not use dummy server (which requires `requests` module not available via pygbag)

--- a/src/settings.py
+++ b/src/settings.py
@@ -42,6 +42,8 @@ SECONDS_PER_GAME_MINUTE = 0.7
 WORLD_TIME_MULTIPLIER = 1.0
 # USE_SERVER = False
 USE_SERVER = True
+# position logging interval (in seconds), lowering this may lead to server issues
+POS_LOG_INTERVAL = 3
 
 IS_WEB = sys.platform in ("emscripten", "wasm")
 # for now, in web mode, do not use dummy server (which requires `requests` module not available via pygbag)
@@ -50,7 +52,7 @@ if not IS_WEB:
     if os.getenv("USE_SERVER") == "true":
         USE_SERVER = True
     else:
-        USE_SERVER = False
+        USE_SERVER = True
 
 # NOTE(larsbutler): Don't change this line at all.
 # WEB_SERVER_URL is populated during build,

--- a/src/sprites/entities/player.py
+++ b/src/sprites/entities/player.py
@@ -11,7 +11,7 @@ from src.events import OPEN_INVENTORY, START_QUAKE, post_event
 from src.gui.interface.emotes import PlayerEmoteManager
 from src.npc.bases.npc_base import NPCBase
 from src.savefile import SaveFile
-from src.settings import BATH_STATUS_TIMEOUT, DEBUG_MODE_VERSION, Coordinate, SoundDict, POS_LOG_INTERVAL
+from src.settings import BATH_STATUS_TIMEOUT, DEBUG_MODE_VERSION, POS_MOVE_LOG_INTERVAL, Coordinate, SoundDict, POS_MIN_LOG_INTERVAL
 from src.sprites.entities.character import Character
 from src.sprites.entities.entity import Entity
 from src.sprites.setup import EntityAsset
@@ -296,12 +296,15 @@ class Player(Character):
         )
 
         if abs(self.direction.x) + abs(self.direction.y) > 0:
-            # print("moving {} {}".format(dt, self.dt_last_pos_log))
             self.dt_last_pos_log += dt
 
-            if self.dt_last_pos_log > POS_LOG_INTERVAL:
+            if self.dt_last_pos_log > POS_MOVE_LOG_INTERVAL:
                 self.send_telemetry("position", {"pos": ", ".join(str(round(v)) for v in self.rect.topleft)})
                 self.dt_last_pos_log = 0
+
+        elif self.dt_last_pos_log > POS_MIN_LOG_INTERVAL:
+            self.send_telemetry("position", {"pos": ", ".join(str(round(v)) for v in self.rect.topleft)})
+            self.dt_last_pos_log = 0
 
 
     # sets the player's transparency and speed according to their health

--- a/src/sprites/entities/player.py
+++ b/src/sprites/entities/player.py
@@ -11,7 +11,7 @@ from src.events import OPEN_INVENTORY, START_QUAKE, post_event
 from src.gui.interface.emotes import PlayerEmoteManager
 from src.npc.bases.npc_base import NPCBase
 from src.savefile import SaveFile
-from src.settings import BATH_STATUS_TIMEOUT, DEBUG_MODE_VERSION, Coordinate, SoundDict
+from src.settings import BATH_STATUS_TIMEOUT, DEBUG_MODE_VERSION, Coordinate, SoundDict, POS_LOG_INTERVAL
 from src.sprites.entities.character import Character
 from src.sprites.entities.entity import Entity
 from src.sprites.setup import EntityAsset
@@ -86,6 +86,7 @@ class Player(Character):
         self.has_horn = save_file.has_horn
         self.has_outgroup_skin = save_file.has_outgroup_skin
         self.study_group: StudyGroup = save_file.study_group
+        self.dt_last_pos_log = 0
 
         self.emote_manager = emote_manager
         self.focused_entity: NPCBase | None = None
@@ -293,6 +294,15 @@ class Player(Character):
             ),
             self.rect.size,
         )
+
+        if abs(self.direction.x) + abs(self.direction.y) > 0:
+            # print("moving {} {}".format(dt, self.dt_last_pos_log))
+            self.dt_last_pos_log += dt
+
+            if self.dt_last_pos_log > POS_LOG_INTERVAL:
+                self.send_telemetry("position", {"pos": ", ".join(str(round(v)) for v in self.rect.topleft)})
+                self.dt_last_pos_log = 0
+
 
     # sets the player's transparency and speed according to their health
 

--- a/src/sprites/entities/player.py
+++ b/src/sprites/entities/player.py
@@ -11,7 +11,14 @@ from src.events import OPEN_INVENTORY, START_QUAKE, post_event
 from src.gui.interface.emotes import PlayerEmoteManager
 from src.npc.bases.npc_base import NPCBase
 from src.savefile import SaveFile
-from src.settings import BATH_STATUS_TIMEOUT, DEBUG_MODE_VERSION, POS_MOVE_LOG_INTERVAL, Coordinate, SoundDict, POS_MIN_LOG_INTERVAL
+from src.settings import (
+    BATH_STATUS_TIMEOUT,
+    DEBUG_MODE_VERSION,
+    POS_MIN_LOG_INTERVAL,
+    POS_MOVE_LOG_INTERVAL,
+    Coordinate,
+    SoundDict,
+)
 from src.sprites.entities.character import Character
 from src.sprites.entities.entity import Entity
 from src.sprites.setup import EntityAsset
@@ -299,13 +306,17 @@ class Player(Character):
             self.dt_last_pos_log += dt
 
             if self.dt_last_pos_log > POS_MOVE_LOG_INTERVAL:
-                self.send_telemetry("position", {"pos": ", ".join(str(round(v)) for v in self.rect.topleft)})
+                self.send_telemetry(
+                    "position",
+                    {"pos": ", ".join(str(round(v)) for v in self.rect.topleft)},
+                )
                 self.dt_last_pos_log = 0
 
         elif self.dt_last_pos_log > POS_MIN_LOG_INTERVAL:
-            self.send_telemetry("position", {"pos": ", ".join(str(round(v)) for v in self.rect.topleft)})
+            self.send_telemetry(
+                "position", {"pos": ", ".join(str(round(v)) for v in self.rect.topleft)}
+            )
             self.dt_last_pos_log = 0
-
 
     # sets the player's transparency and speed according to their health
 

--- a/src/sprites/entities/player.py
+++ b/src/sprites/entities/player.py
@@ -193,12 +193,6 @@ class Player(Character):
                 self.emote_manager.show_emote(
                     self, self.emote_manager.emote_wheel._current_emote
                 )
-                payload = {}
-                payload["emote_index"] = self.emote_manager.emote_wheel.emote_index
-                payload["emote_name"] = self.emote_manager.emote_wheel._emotes[
-                    payload["emote_index"]
-                ]
-                self.send_telemetry("player_interaction", payload)
                 self.emote_manager.toggle_emote_wheel()
 
         # movement

--- a/src/tutorial/tutorial.py
+++ b/src/tutorial/tutorial.py
@@ -167,7 +167,7 @@ class Tutorial:
             case 3:
                 # check if the player achieved task "plant a crop"
                 if (
-                    True in self.level.crop_planted
+                    self.level.crop_planted
                     and self.dialogue_manager._get_current_tb().finished_advancing
                 ):
                     self.switch_to_task(4)


### PR DESCRIPTION
Enhanced Telemetry logging:

New log types:

- "switch_map", with payload keys "old_map" and "new_map" (this triggers when walking across map transitions, when entering Minigame and so on.
- Moved emotewheel log to enable logging npc type and location of both player and npc. Is only triggered if an npc is close enough for the reaction to actually trigger
- "tool_statistics", triggered after a configurable number (TOOLS_LOG_INTERVAL) of tool or seed uses, payload is a json with all tools and seeds and the number of uses by the player
- "minigame_complete" with payload keys "self_time", "opp_time". Win or Loss is not explicitly stated but you can compare the times
- "position" logs the player position (coordinates). The coordinates are map specific, so this only makes sense when analyzed in combination with the "switch_map" events to determine which map the player was on. To avoid lagging, the position is logged only when the player is standing still and only after cumulatively moving for at least n seconds since the last log (n can be configured in POS_MIN_LOG_INTERVAL). If a player is moving continuously for POS_MOVE_LOG_INTERVAL a log is triggered too.

Overall, the constants are currently configured such that it should not be possible to overload the server and stay well below 30 requests per minute.
