### PR TITLE
Fix missing abstract method implementation.

### DIFF
--- a/src/screens/minigames/cow_herding_overlay.py
+++ b/src/screens/minigames/cow_herding_overlay.py
@@ -122,6 +122,9 @@ class _CowHerdingScoreboard(AbstractMenu):
 
         self.update_buttons(dt)
 
+    def draw_description(self):
+        pass
+
 
 class _CowHerdingOverlay:
     display_surface: pygame.Surface


### PR DESCRIPTION
This PR fixes the missing abstract method implementation, which appears after PR #339.
The game crashed in a minigame.

[x] I have tested this change on the local server and it works as expected.
[x] I have made sure that the code follows the formatting and style guidelines of the project.