### PR TITLE
fix ingroup-necklace-sequence

### DIFF
--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -761,6 +761,10 @@ class Level:
                     ScriptedSequenceType.INGROUP_NECKLACE_SEQUENCE,
                 ]:
                     npcs = self.limit_npcs_amount(npcs)
+                if sequence_type in decide_sequence:
+                    for npc in npcs:
+                        npc.has_hat = True
+                        npc.has_necklace = True
 
                 other_npcs = [
                     npc
@@ -867,6 +871,7 @@ class Level:
         elif sequence_type == ScriptedSequenceType.PLAYER_BIRTHDAY_SEQUENCE:
             pass
         elif sequence_type == ScriptedSequenceType.INGROUP_NECKLACE_SEQUENCE:
+            npc.has_hat = True
             npc.has_necklace = True
         elif sequence_type == ScriptedSequenceType.GROUP_MARKET_PASSIVE_PLAYER_SEQUENCE:
             buy_list = TOMATO_OR_CORN_LIST


### PR DESCRIPTION
This PR fixes ingroup_necklace_sequence, group_market_passive_player_sequence, and group_market_active_player_sequence.
To now, there were two minor inconsistencies.
The first is that in the ingroup_necklace_sequence, the NPC who gets the necklace should already be wearing a hat. Second, the group_market_passive_player_sequence and the group_market_active_player_sequence should only show NPCs with hats and necklaces.
At this moment it should work correctly.
![Zrzut ekranu 2025-03-12 173344](https://github.com/user-attachments/assets/e175d20a-3b94-47f9-940f-d1a36c83765d)

[x] I have tested this change on the local server and it works as expected.
[x] I have made sure that the code follows the formatting and style guidelines of the project.
